### PR TITLE
feat(crm): add task tree view

### DIFF
--- a/api/src/modules/crm/migrations/0005_task_parent.py
+++ b/api/src/modules/crm/migrations/0005_task_parent.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('crm', '0004_remove_taskstatus_kanban_column'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='task',
+            name='parent',
+            field=models.ForeignKey(
+                on_delete=models.CASCADE,
+                related_name='subtasks',
+                null=True,
+                blank=True,
+                to='crm.task',
+                verbose_name='Родительская задача',
+            ),
+        ),
+    ]

--- a/api/src/modules/crm/models.py
+++ b/api/src/modules/crm/models.py
@@ -207,6 +207,7 @@ class Task(models.Model):
     project = models.ForeignKey(Project, on_delete=models.CASCADE, related_name='tasks', verbose_name='Проект')
     assignee = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True, related_name='assigned_tasks', verbose_name='Исполнитель')
     creator = models.ForeignKey(User, on_delete=models.CASCADE, related_name='created_tasks', verbose_name='Создатель')
+    parent = models.ForeignKey('self', on_delete=models.CASCADE, null=True, blank=True, related_name='subtasks', verbose_name='Родительская задача')
     
     # Новые поля с внешними ключами
     status_ref = models.ForeignKey(TaskStatus, on_delete=models.SET_NULL, null=True, blank=True, related_name='tasks', verbose_name='Статус (новый)')

--- a/api/src/modules/crm/serializers.py
+++ b/api/src/modules/crm/serializers.py
@@ -215,6 +215,43 @@ class TimeLogSerializer(serializers.ModelSerializer):
         return super().create(validated_data)
 
 
+class TaskListSerializer(serializers.ModelSerializer):
+    """Сериализатор списка задач"""
+    assignee = CRMUserSerializer(read_only=True)
+    creator = CRMUserSerializer(read_only=True)
+    project = ProjectListSerializer(read_only=True)
+
+    # Новые поля для статусов и приоритетов
+    status_ref = TaskStatusSerializer(read_only=True)
+    priority_ref = TaskPrioritySerializer(read_only=True)
+    current_status = serializers.CharField(read_only=True)
+    current_priority = serializers.CharField(read_only=True)
+    status_display = serializers.CharField(read_only=True)
+    priority_display = serializers.CharField(read_only=True)
+
+    parent = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    comment_count = serializers.SerializerMethodField()
+    attachment_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Task
+        fields = [
+            'id', 'title', 'description', 'project', 'assignee', 'creator',
+            'status', 'priority', 'start_date', 'due_date', 'completed_at',
+            'created_at', 'updated_at', 'estimated_hours', 'actual_hours',
+            'kanban_order', 'comment_count', 'attachment_count',
+            'status_ref', 'priority_ref', 'current_status', 'current_priority',
+            'status_display', 'priority_display', 'parent'
+        ]
+
+    def get_comment_count(self, obj):
+        return obj.comments.count()
+
+    def get_attachment_count(self, obj):
+        return obj.attachments.count()
+
+
 class TaskSerializer(serializers.ModelSerializer):
     """Сериализатор задачи"""
     assignee = CRMUserSerializer(read_only=True)
@@ -222,6 +259,9 @@ class TaskSerializer(serializers.ModelSerializer):
     project = ProjectListSerializer(read_only=True)
     assignee_id = serializers.IntegerField(write_only=True, required=False, allow_null=True)
     project_id = serializers.IntegerField(write_only=True)
+    parent = TaskListSerializer(read_only=True)
+    parent_id = serializers.IntegerField(write_only=True, required=False, allow_null=True)
+    subtasks = TaskListSerializer(many=True, read_only=True)
     
     # Новые поля для статусов и приоритетов
     status_ref = TaskStatusSerializer(read_only=True)
@@ -250,7 +290,7 @@ class TaskSerializer(serializers.ModelSerializer):
             'id', 'title', 'description', 'project', 'project_id', 'assignee', 'assignee_id',
             'creator', 'status', 'priority', 'start_date', 'due_date', 'completed_at',
             'created_at', 'updated_at', 'estimated_hours', 'actual_hours', 'kanban_order',
-            'comments', 'attachments', 'time_logs', 'total_time',
+            'comments', 'attachments', 'time_logs', 'total_time', 'parent', 'parent_id', 'subtasks',
             'status_ref', 'priority_ref', 'status_ref_id', 'priority_ref_id',
             'current_status', 'current_priority', 'status_display', 'priority_display'
         ]
@@ -273,40 +313,6 @@ class TaskSerializer(serializers.ModelSerializer):
         validated_data['creator'] = self.context['request'].user
         return super().create(validated_data)
 
-
-class TaskListSerializer(serializers.ModelSerializer):
-    """Сериализатор списка задач"""
-    assignee = CRMUserSerializer(read_only=True)
-    creator = CRMUserSerializer(read_only=True)
-    project = ProjectListSerializer(read_only=True)
-    
-    # Новые поля для статусов и приоритетов
-    status_ref = TaskStatusSerializer(read_only=True)
-    priority_ref = TaskPrioritySerializer(read_only=True)
-    current_status = serializers.CharField(read_only=True)
-    current_priority = serializers.CharField(read_only=True)
-    status_display = serializers.CharField(read_only=True)
-    priority_display = serializers.CharField(read_only=True)
-    
-    comment_count = serializers.SerializerMethodField()
-    attachment_count = serializers.SerializerMethodField()
-    
-    class Meta:
-        model = Task
-        fields = [
-            'id', 'title', 'description', 'project', 'assignee', 'creator',
-            'status', 'priority', 'start_date', 'due_date', 'completed_at',
-            'created_at', 'updated_at', 'estimated_hours', 'actual_hours',
-            'kanban_order', 'comment_count', 'attachment_count',
-            'status_ref', 'priority_ref', 'current_status', 'current_priority',
-            'status_display', 'priority_display'
-        ]
-    
-    def get_comment_count(self, obj):
-        return obj.comments.count()
-    
-    def get_attachment_count(self, obj):
-        return obj.attachments.count()
 
 
 class TaskCalendarSerializer(serializers.ModelSerializer):

--- a/api/src/modules/crm/views.py
+++ b/api/src/modules/crm/views.py
@@ -267,7 +267,7 @@ class TaskViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
     queryset = Task.objects.all()
     permission_classes = [IsAuthenticated]
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
-    filterset_fields = ['status', 'priority', 'project', 'assignee', 'creator']
+    filterset_fields = ['status', 'priority', 'project', 'assignee', 'creator', 'parent']
     search_fields = ['title', 'description']
     ordering_fields = ['created_at', 'due_date', 'priority', 'kanban_order']
     ordering = ['kanban_order', '-created_at']

--- a/client/src/modules/crm/project-management/ProjectDetail.vue
+++ b/client/src/modules/crm/project-management/ProjectDetail.vue
@@ -238,10 +238,17 @@
             <ListTodo :size="24" />
             <h2>Задачи проекта</h2>
           </div>
-          <button class="btn btn-primary" @click="createTask">
-            <Plus :size="16" />
-            <span>Добавить задачу</span>
-          </button>
+          <div class="section-actions">
+            <button class="btn btn-outline-primary" @click="toggleTaskView">
+              <GitBranch :size="16" v-if="!showTaskTree" />
+              <ListTodo :size="16" v-else />
+              <span>{{ showTaskTree ? 'Список' : 'Дерево' }}</span>
+            </button>
+            <button class="btn btn-primary" @click="createTask">
+              <Plus :size="16" />
+              <span>Добавить задачу</span>
+            </button>
+          </div>
         </div>
         
         <div class="tasks-content">
@@ -256,68 +263,76 @@
             </button>
           </div>
           
-          <!-- Таблица задач -->
-          <div v-else class="tasks-table-container">
-            <div class="table-responsive">
-              <table class="tasks-table">
-                <thead>
-                  <tr>
-                    <th>Задача</th>
-                    <th>Исполнитель</th>
-                    <th>Статус</th>
-                    <th>Приоритет</th>
-                    <th>Срок</th>
-                    <th>Действия</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="task in tasks" :key="task.id" class="task-row">
-                    <td class="task-cell">
-                      <div class="task-info">
-                        <h4 class="task-title">{{ task.title }}</h4>
-                        <p class="task-description" v-if="task.description">
-                          {{ truncateText(task.description, 100) }}
-                        </p>
-                      </div>
-                    </td>
-                    <td class="assignee-cell">
-                      <div class="assignee-info" v-if="task.assignee">
-                        <img :src="getAvatarUrl(task.assignee)" 
-                             :alt="getUserDisplayName(task.assignee)"
-                             class="assignee-avatar">
-                        <span class="assignee-name">{{ getUserDisplayName(task.assignee) }}</span>
-                      </div>
-                      <span v-else class="no-assignee">Не назначен</span>
-                    </td>
-                    <td class="status-cell">
-                      <span class="badge status-badge" :class="getTaskStatusClass(task.status)">
-                        {{ getTaskStatusText(task.status) }}
-                      </span>
-                    </td>
-                    <td class="priority-cell">
-                      <span class="badge priority-badge" :class="getPriorityClass(task.priority)">
-                        {{ getPriorityText(task.priority) }}
-                      </span>
-                    </td>
-                    <td class="due-date-cell">
-                      <span :class="getDueDateClass(task.due_date, task.status)">
-                        <Clock :size="14" />
-                        {{ formatDate(task.due_date) || '-' }}
-                      </span>
-                    </td>
-                    <td class="actions-cell">
-                      <div class="action-buttons">
-                        <button class="btn btn-edit-icon" @click="editTask(task)" title="Редактировать">
-                          <Edit :size="14" />
-                        </button>
-                        <button class="btn btn-delete-icon" @click="deleteTask(task)" title="Удалить">
-                          <Trash2 :size="14" />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+          <!-- Таблица задач или дерево -->
+          <div v-else>
+            <div v-if="showTaskTree" class="task-tree-container">
+              <ProjectTasksTree :project="project" :tasks="tasks" />
+            </div>
+            <div v-else class="tasks-table-container">
+              <div class="table-responsive">
+                <table class="tasks-table">
+                  <thead>
+                    <tr>
+                      <th>Задача</th>
+                      <th>Исполнитель</th>
+                      <th>Статус</th>
+                      <th>Приоритет</th>
+                      <th>Срок</th>
+                      <th>Действия</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="task in tasks" :key="task.id" class="task-row">
+                      <td class="task-cell">
+                        <div class="task-info">
+                          <h4 class="task-title">{{ task.title }}</h4>
+                          <p class="task-description" v-if="task.description">
+                            {{ truncateText(task.description, 100) }}
+                          </p>
+                        </div>
+                      </td>
+                      <td class="assignee-cell">
+                        <div class="assignee-info" v-if="task.assignee">
+                          <img :src="getAvatarUrl(task.assignee)"
+                               :alt="getUserDisplayName(task.assignee)"
+                               class="assignee-avatar">
+                          <span class="assignee-name">{{ getUserDisplayName(task.assignee) }}</span>
+                        </div>
+                        <span v-else class="no-assignee">Не назначен</span>
+                      </td>
+                      <td class="status-cell">
+                        <span class="badge status-badge" :class="getTaskStatusClass(task.status)">
+                          {{ getTaskStatusText(task.status) }}
+                        </span>
+                      </td>
+                      <td class="priority-cell">
+                        <span class="badge priority-badge" :class="getPriorityClass(task.priority)">
+                          {{ getPriorityText(task.priority) }}
+                        </span>
+                      </td>
+                      <td class="due-date-cell">
+                        <span :class="getDueDateClass(task.due_date, task.status)">
+                          <Clock :size="14" />
+                          {{ formatDate(task.due_date) || '-' }}
+                        </span>
+                      </td>
+                      <td class="actions-cell">
+                        <div class="action-buttons">
+                          <button class="btn btn-edit-icon" @click="createSubTask(task)" title="Добавить подзадачу">
+                            <Plus :size="14" />
+                          </button>
+                          <button class="btn btn-edit-icon" @click="editTask(task)" title="Редактировать">
+                            <Edit :size="14" />
+                          </button>
+                          <button class="btn btn-delete-icon" @click="deleteTask(task)" title="Удалить">
+                            <Trash2 :size="14" />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </div>
           </div>
         </div>
@@ -593,10 +608,11 @@
 
 <script>
 import { Modal } from 'bootstrap'
-import { Edit, Trash2, Plus, Home, Info, PieChart, ListTodo, Calendar, Clock, Users, CheckCircle, AlertTriangle, UserPlus, UserMinus } from 'lucide-vue-next'
+import { Edit, Trash2, Plus, Home, Info, PieChart, ListTodo, Calendar, Clock, Users, CheckCircle, AlertTriangle, UserPlus, UserMinus, GitBranch } from 'lucide-vue-next'
 import projectManagementApi from '@/modules/crm/project-management/js/projectManagementApi.js'
 import { useNotifications } from '@/modules/lms/composables/useNotifications'
 import { getAvatarUrl } from '@/modules/cms/js/avatarUtils.js'
+import ProjectTasksTree from './ProjectTasksTree.vue'
 
 export default {
   name: 'ProjectDetail',
@@ -614,7 +630,9 @@ export default {
     CheckCircle,
     AlertTriangle,
     UserPlus,
-    UserMinus
+    UserMinus,
+    GitBranch,
+    ProjectTasksTree
   },
   setup() {
     const { showSuccess, showError, showConfirmDialog, closeConfirmDialog } = useNotifications()
@@ -626,6 +644,7 @@ export default {
       error: null,
       project: null,
       tasks: [],
+      showTaskTree: false,
       users: [],
       currentTask: {
         title: '',
@@ -635,7 +654,8 @@ export default {
         priority: 'medium',
         start_date: '',
         due_date: '',
-        estimated_hours: null
+        estimated_hours: null,
+        parent_id: null
       },
       currentProject: {
         name: '',
@@ -813,6 +833,9 @@ export default {
     }
   },
   methods: {
+    toggleTaskView() {
+      this.showTaskTree = !this.showTaskTree
+    },
     async loadProjectData() {
       const projectId = this.$route.params.id
       if (!projectId) {
@@ -934,13 +957,13 @@ export default {
       modal.show()
     },
 
-    createTask() {
+    createTask(parentTask = null) {
       if (!this.project) return
-      
+
       // Устанавливаем значения по умолчанию из загруженных данных
       const defaultTaskStatus = this.taskStatuses.find(s => s.is_default) || this.taskStatuses[0]
       const defaultTaskPriority = this.taskPriorities.find(p => p.is_default) || this.taskPriorities[0]
-      
+
       this.isEditingTask = false
       this.currentTask = {
         title: '',
@@ -951,11 +974,16 @@ export default {
         priority: defaultTaskPriority ? defaultTaskPriority.code : 'medium',
         start_date: '',
         due_date: '',
-        estimated_hours: null
+        estimated_hours: null,
+        parent_id: parentTask ? parentTask.id : null
       }
-      
+
       const modal = new Modal(document.getElementById('taskModal'))
       modal.show()
+    },
+
+    createSubTask(task) {
+      this.createTask(task)
     },
 
     editTask(task) {
@@ -970,9 +998,10 @@ export default {
         priority: task.priority,
         start_date: task.start_date ? this.formatDateTimeLocal(new Date(task.start_date)) : '',
         due_date: task.due_date ? this.formatDateTimeLocal(new Date(task.due_date)) : '',
-        estimated_hours: task.estimated_hours
+        estimated_hours: task.estimated_hours,
+        parent_id: task.parent || null
       }
-      
+
       const modal = new Modal(document.getElementById('taskModal'))
       modal.show()
     },
@@ -1038,7 +1067,8 @@ export default {
           assignee_id: this.currentTask.assignee_id || null,
           start_date: this.currentTask.start_date || null,
           due_date: this.currentTask.due_date || null,
-          estimated_hours: this.currentTask.estimated_hours || null
+          estimated_hours: this.currentTask.estimated_hours || null,
+          parent_id: this.currentTask.parent_id || null
         }
         
         if (this.isEditingTask) {
@@ -1950,7 +1980,12 @@ export default {
         margin: 0;
       }
     }
-    
+
+    .section-actions {
+      display: flex;
+      gap: 0.75rem;
+    }
+
     .btn {
       display: flex;
       align-items: center;
@@ -1969,7 +2004,7 @@ export default {
   
   .tasks-content {
     padding: 1.5rem;
-    
+
     .empty-state {
       text-align: center;
       padding: 3rem 2rem;
@@ -1997,6 +2032,10 @@ export default {
         font-weight: 600;
         border-radius: 8px;
       }
+    }
+
+    .task-tree-container {
+      height: 400px;
     }
   }
 }

--- a/client/src/modules/crm/project-management/ProjectTasksTree.vue
+++ b/client/src/modules/crm/project-management/ProjectTasksTree.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="task-tree">
+    <VueFlow :nodes="nodes" :edges="edges" fit-view :zoom-on-scroll="false" :nodes-connectable="false" :edges-connectable="false" />
+  </div>
+</template>
+
+<script setup>
+import '@vue-flow/core/dist/style.css'
+import '@vue-flow/core/dist/theme-default.css'
+import { ref, watch } from 'vue'
+import { VueFlow } from '@vue-flow/core'
+
+const props = defineProps({
+  project: { type: Object, required: true },
+  tasks: { type: Array, default: () => [] }
+})
+
+const nodes = ref([])
+const edges = ref([])
+
+function buildGraph() {
+  const rootId = `project-${props.project.id}`
+  nodes.value = [
+    {
+      id: rootId,
+      data: { label: props.project.name },
+      position: { x: 0, y: 0 },
+      draggable: false,
+      type: 'input'
+    }
+  ]
+  edges.value = []
+
+  const tasksByParent = {}
+  props.tasks.forEach(task => {
+    const parentId = task.parent || null
+    if (!tasksByParent[parentId]) tasksByParent[parentId] = []
+    tasksByParent[parentId].push(task)
+  })
+
+  const levelSpacing = 150
+  const nodeSpacing = 180
+
+  function addChildren(parentId, tasks, depth, startX) {
+    tasks.forEach((task, index) => {
+      const nodeId = `task-${task.id}`
+      const x = startX + index * nodeSpacing
+      const y = depth * levelSpacing
+      nodes.value.push({
+        id: nodeId,
+        data: { label: task.title },
+        position: { x, y },
+        draggable: false
+      })
+      edges.value.push({
+        id: `edge-${parentId || 'root'}-${task.id}`,
+        source: parentId ? `task-${parentId}` : rootId,
+        target: nodeId
+      })
+      const children = tasksByParent[task.id]
+      if (children && children.length) {
+        addChildren(task.id, children, depth + 1, x)
+      }
+    })
+  }
+
+  addChildren(null, tasksByParent[null] || [], 1, 0)
+}
+
+watch(() => props.tasks, buildGraph, { immediate: true })
+watch(() => props.project, buildGraph)
+</script>
+
+<style scoped>
+.task-tree {
+  width: 100%;
+  height: 100%;
+}
+</style>
+

--- a/client/src/modules/crm/project-management/TasksList.vue
+++ b/client/src/modules/crm/project-management/TasksList.vue
@@ -174,6 +174,9 @@
                 </td>
                 <td @click.stop class="actions-cell">
                   <div class="action-buttons">
+                    <button class="btn btn-edit-icon" @click="createSubTask(task)" title="Добавить подзадачу">
+                      <Plus />
+                    </button>
                     <button class="btn btn-edit-icon" @click="editTask(task)" title="Редактировать">
                       <Edit />
                     </button>
@@ -497,7 +500,7 @@
 
 <script>
 import { Modal } from 'bootstrap'
-import { Edit, Trash2 } from 'lucide-vue-next'
+import { Edit, Trash2, Plus } from 'lucide-vue-next'
 import projectManagementApi from '@/modules/crm/project-management/js/projectManagementApi.js'
 import { useNotifications } from '@/modules/lms/composables/useNotifications'
 import { getAvatarUrl } from '@/modules/cms/js/avatarUtils.js'
@@ -506,7 +509,8 @@ export default {
   name: 'TasksList',
   components: {
     Edit,
-    Trash2
+    Trash2,
+    Plus
   },
   props: {
     managementMode: {
@@ -549,7 +553,8 @@ export default {
         priority: 'medium',
         start_date: '',
         due_date: '',
-        estimated_hours: null
+        estimated_hours: null,
+        parent_id: null
       },
       selectedTask: {},
       isEditing: false,
@@ -739,31 +744,36 @@ export default {
       console.log('Статусы и приоритеты задач обновлены:', this.taskStatuses.length, this.taskPriorities.length)
     },
     
-    async createTask() {
+    async createTask(parentTask = null) {
       this.isEditing = false
-      
+
       // Обновляем статусы и приоритеты перед созданием задачи
       console.log('Обновляем статусы перед созданием задачи...')
       await this.refreshStatusesAndPriorities()
-      
+
       // Устанавливаем значения по умолчанию из загруженных данных
       const defaultStatus = this.taskStatuses.find(s => s.is_default) || this.taskStatuses[0]
       const defaultPriority = this.taskPriorities.find(p => p.is_default) || this.taskPriorities[0]
-      
+
       this.currentTask = {
         title: '',
         description: '',
-        project_id: '',
+        project_id: parentTask?.project?.id || '',
         assignee_id: '',
         status: defaultStatus ? defaultStatus.code : 'todo',
         priority: defaultPriority ? defaultPriority.code : 'medium',
         start_date: '',
         due_date: '',
-        estimated_hours: null
+        estimated_hours: null,
+        parent_id: parentTask ? parentTask.id : null
       }
-      
+
       const modal = new Modal(document.getElementById('taskModal'))
       modal.show()
+    },
+
+    createSubTask(task) {
+      this.createTask(task)
     },
     
     editTask(task) {
@@ -778,7 +788,8 @@ export default {
         priority: task.priority,
         start_date: task.start_date ? this.formatDateTimeLocal(new Date(task.start_date)) : '',
         due_date: task.due_date ? this.formatDateTimeLocal(new Date(task.due_date)) : '',
-        estimated_hours: task.estimated_hours
+        estimated_hours: task.estimated_hours,
+        parent_id: task.parent || null
       }
       
       const modal = new Modal(document.getElementById('taskModal'))
@@ -808,7 +819,8 @@ export default {
           assignee_id: this.currentTask.assignee_id || null,
           start_date: this.currentTask.start_date || null,
           due_date: this.currentTask.due_date || null,
-          estimated_hours: this.currentTask.estimated_hours || null
+          estimated_hours: this.currentTask.estimated_hours || null,
+          parent_id: this.currentTask.parent_id || null
         }
         
         if (this.isEditing) {


### PR DESCRIPTION
## Summary
- add ProjectTasksTree component using VueFlow to render tasks graphically
- allow toggling between table and tree view on project detail page
- add nested subtask support across backend and UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 370 errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68968e3efc7c832990a3404bcb41a86c