### PR TITLE
feat(crm): add task tree view and organizations support

### DIFF
--- a/api/src/modules/crm/migrations/0005_task_parent.py
+++ b/api/src/modules/crm/migrations/0005_task_parent.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('crm', '0004_remove_taskstatus_kanban_column'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='task',
+            name='parent',
+            field=models.ForeignKey(
+                on_delete=models.CASCADE,
+                related_name='subtasks',
+                null=True,
+                blank=True,
+                to='crm.task',
+                verbose_name='Родительская задача',
+            ),
+        ),
+    ]

--- a/api/src/modules/crm/migrations/0006_organization.py
+++ b/api/src/modules/crm/migrations/0006_organization.py
@@ -1,0 +1,55 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('crm', '0005_task_parent'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Organization',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=255, verbose_name='Название организации')),
+                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Дата создания')),
+                ('updated_at', models.DateTimeField(auto_now=True, verbose_name='Дата обновления')),
+                ('owner', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='owned_organizations', to=settings.AUTH_USER_MODEL, verbose_name='Владелец')),
+            ],
+            options={
+                'app_label': 'crm',
+                'verbose_name': 'Организация',
+                'verbose_name_plural': 'Организации',
+            },
+        ),
+        migrations.CreateModel(
+            name='OrganizationMember',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('is_accepted', models.BooleanField(default=False, verbose_name='Приглашение принято')),
+                ('invited_at', models.DateTimeField(auto_now_add=True, verbose_name='Дата приглашения')),
+                ('joined_at', models.DateTimeField(blank=True, null=True, verbose_name='Дата присоединения')),
+                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='memberships', to='crm.organization')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='organization_memberships', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'app_label': 'crm',
+                'verbose_name': 'Участник организации',
+                'verbose_name_plural': 'Участники организаций',
+                'unique_together': {('organization', 'user')},
+            },
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='members',
+            field=models.ManyToManyField(related_name='organizations', through='crm.OrganizationMember', to=settings.AUTH_USER_MODEL, verbose_name='Участники'),
+        ),
+        migrations.AddField(
+            model_name='project',
+            name='organization',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='projects', to='crm.organization', verbose_name='Организация'),
+        ),
+    ]

--- a/api/src/modules/crm/migrations/0007_organization_invites.py
+++ b/api/src/modules/crm/migrations/0007_organization_invites.py
@@ -1,0 +1,144 @@
+from django.db import migrations, models
+from django.conf import settings
+import django.db.models.deletion
+import django.utils.timezone
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('crm', '0006_organization'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='organization',
+            name='slug',
+            field=models.SlugField(blank=True, unique=True, verbose_name='Слаг'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='description',
+            field=models.TextField(blank=True, verbose_name='Описание'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='logo_url',
+            field=models.URLField(blank=True, verbose_name='Логотип'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='industry',
+            field=models.CharField(blank=True, max_length=255, verbose_name='Отрасль'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='website',
+            field=models.URLField(blank=True, verbose_name='Сайт'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='email',
+            field=models.EmailField(blank=True, max_length=254, verbose_name='Email'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='phone',
+            field=models.CharField(blank=True, max_length=50, verbose_name='Телефон'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='country',
+            field=models.CharField(blank=True, max_length=100, verbose_name='Страна'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='timezone',
+            field=models.CharField(blank=True, max_length=50, verbose_name='Часовой пояс'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='address',
+            field=models.CharField(blank=True, max_length=255, verbose_name='Адрес'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='billing_name',
+            field=models.CharField(blank=True, max_length=255, verbose_name='Плательщик'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='billing_vat',
+            field=models.CharField(blank=True, max_length=50, verbose_name='НДС'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='billing_address',
+            field=models.CharField(blank=True, max_length=255, verbose_name='Адрес для счетов'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='visibility',
+            field=models.CharField(choices=[('private', 'private'), ('by_invite', 'by_invite')], default='by_invite', max_length=20, verbose_name='Видимость'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='default_role',
+            field=models.CharField(choices=[('member', 'member'), ('viewer', 'viewer')], default='member', max_length=20, verbose_name='Роль по умолчанию'),
+        ),
+        migrations.AddField(
+            model_name='organization',
+            name='status',
+            field=models.CharField(choices=[('active', 'active'), ('archived', 'archived')], default='active', max_length=20, verbose_name='Статус'),
+        ),
+        migrations.RemoveField(
+            model_name='organizationmember',
+            name='is_accepted',
+        ),
+        migrations.RemoveField(
+            model_name='organizationmember',
+            name='joined_at',
+        ),
+        migrations.AddField(
+            model_name='organizationmember',
+            name='role',
+            field=models.CharField(choices=[('owner','owner'),('admin','admin'),('member','member'),('viewer','viewer')], default='member', max_length=20, verbose_name='Роль'),
+        ),
+        migrations.AddField(
+            model_name='organizationmember',
+            name='status',
+            field=models.CharField(choices=[('pending','pending'),('accepted','accepted'),('declined','declined'),('revoked','revoked')], default='pending', max_length=20, verbose_name='Статус'),
+        ),
+        migrations.AddField(
+            model_name='organizationmember',
+            name='invited_by',
+            field=models.ForeignKey(null=True, blank=True, on_delete=models.SET_NULL, related_name='sent_org_invites', to=settings.AUTH_USER_MODEL, verbose_name='Кем приглашен'),
+        ),
+        migrations.AddField(
+            model_name='organizationmember',
+            name='responded_at',
+            field=models.DateTimeField(blank=True, null=True, verbose_name='Дата ответа'),
+        ),
+        migrations.CreateModel(
+            name='OrganizationInvite',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('email', models.EmailField(max_length=254, verbose_name='Email')),
+                ('token', models.CharField(max_length=64, unique=True)),
+                ('expires_at', models.DateTimeField(blank=True, null=True, verbose_name='Истекает')),
+                ('status', models.CharField(choices=[('pending','pending'),('accepted','accepted'),('declined','declined'),('expired','expired')], default='pending', max_length=20, verbose_name='Статус')),
+                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Дата создания')),
+                ('responded_at', models.DateTimeField(blank=True, null=True, verbose_name='Дата ответа')),
+                ('organization', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='invites', to='crm.organization')),
+                ('invited_by', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='organization_invites', to=settings.AUTH_USER_MODEL, verbose_name='Пригласивший')),
+            ],
+            options={
+                'verbose_name': 'Приглашение в организацию',
+                'verbose_name_plural': 'Приглашения в организации',
+            },
+        ),
+        migrations.AddField(
+            model_name='task',
+            name='organization',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='tasks', to='crm.organization', verbose_name='Организация'),
+        ),
+    ]

--- a/api/src/modules/crm/models.py
+++ b/api/src/modules/crm/models.py
@@ -1,5 +1,9 @@
 from django.db import models
 from django.contrib.auth import get_user_model
+from django.utils import timezone
+from django.utils.text import slugify
+from datetime import timedelta
+import secrets
 
 User = get_user_model()
 
@@ -92,6 +96,128 @@ class TaskPriority(models.Model):
     def __str__(self):
         return self.name
 
+# Организации
+
+class Organization(models.Model):
+    """Организация в CRM"""
+
+    VISIBILITY_CHOICES = [
+        ('private', 'private'),
+        ('by_invite', 'by_invite'),
+    ]
+    ROLE_CHOICES = [
+        ('member', 'member'),
+        ('viewer', 'viewer'),
+    ]
+    STATUS_CHOICES = [
+        ('active', 'active'),
+        ('archived', 'archived'),
+    ]
+
+    name = models.CharField(max_length=255, verbose_name='Название организации')
+    slug = models.SlugField(unique=True, blank=True, verbose_name='Слаг')
+    description = models.TextField(blank=True, verbose_name='Описание')
+    logo_url = models.URLField(blank=True, verbose_name='Логотип')
+    industry = models.CharField(max_length=255, blank=True, verbose_name='Отрасль')
+    website = models.URLField(blank=True, verbose_name='Сайт')
+    email = models.EmailField(blank=True, verbose_name='Email')
+    phone = models.CharField(max_length=50, blank=True, verbose_name='Телефон')
+    country = models.CharField(max_length=100, blank=True, verbose_name='Страна')
+    timezone = models.CharField(max_length=50, blank=True, verbose_name='Часовой пояс')
+    address = models.CharField(max_length=255, blank=True, verbose_name='Адрес')
+    billing_name = models.CharField(max_length=255, blank=True, verbose_name='Плательщик')
+    billing_vat = models.CharField(max_length=50, blank=True, verbose_name='НДС')
+    billing_address = models.CharField(max_length=255, blank=True, verbose_name='Адрес для счетов')
+    owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name='owned_organizations', verbose_name='Владелец')
+    members = models.ManyToManyField(User, through='OrganizationMember', related_name='organizations', verbose_name='Участники')
+    visibility = models.CharField(max_length=20, choices=VISIBILITY_CHOICES, default='by_invite', verbose_name='Видимость')
+    default_role = models.CharField(max_length=20, choices=ROLE_CHOICES, default='member', verbose_name='Роль по умолчанию')
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='active', verbose_name='Статус')
+    created_at = models.DateTimeField(auto_now_add=True, verbose_name='Дата создания')
+    updated_at = models.DateTimeField(auto_now=True, verbose_name='Дата обновления')
+
+    class Meta:
+        app_label = 'crm'
+        verbose_name = 'Организация'
+        verbose_name_plural = 'Организации'
+
+    def __str__(self):
+        return self.name
+
+    def save(self, *args, **kwargs):
+        if not self.slug:
+            self.slug = slugify(self.name)
+        super().save(*args, **kwargs)
+
+
+class OrganizationMember(models.Model):
+    """Участник организации"""
+
+    ROLE_CHOICES = [
+        ('owner', 'owner'),
+        ('admin', 'admin'),
+        ('member', 'member'),
+        ('viewer', 'viewer'),
+    ]
+    STATUS_CHOICES = [
+        ('pending', 'pending'),
+        ('accepted', 'accepted'),
+        ('declined', 'declined'),
+        ('revoked', 'revoked'),
+    ]
+
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name='memberships')
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='organization_memberships')
+    role = models.CharField(max_length=20, choices=ROLE_CHOICES, default='member', verbose_name='Роль')
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='pending', verbose_name='Статус')
+    invited_by = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True, related_name='sent_org_invites', verbose_name='Кем приглашен')
+    invited_at = models.DateTimeField(auto_now_add=True, verbose_name='Дата приглашения')
+    responded_at = models.DateTimeField(null=True, blank=True, verbose_name='Дата ответа')
+
+    class Meta:
+        app_label = 'crm'
+        verbose_name = 'Участник организации'
+        verbose_name_plural = 'Участники организаций'
+        unique_together = ['organization', 'user']
+
+    def __str__(self):
+        return f"{self.user.get_full_name()} - {self.organization.name}"
+
+
+class OrganizationInvite(models.Model):
+    """Приглашение в организацию"""
+
+    STATUS_CHOICES = [
+        ('pending', 'pending'),
+        ('accepted', 'accepted'),
+        ('declined', 'declined'),
+        ('expired', 'expired'),
+    ]
+
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name='invites')
+    email = models.EmailField(verbose_name='Email')
+    token = models.CharField(max_length=64, unique=True, editable=False)
+    expires_at = models.DateTimeField(null=True, blank=True, verbose_name='Истекает')
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='pending', verbose_name='Статус')
+    invited_by = models.ForeignKey(User, on_delete=models.CASCADE, related_name='organization_invites', verbose_name='Пригласивший')
+    created_at = models.DateTimeField(auto_now_add=True, verbose_name='Дата создания')
+    responded_at = models.DateTimeField(null=True, blank=True, verbose_name='Дата ответа')
+
+    class Meta:
+        app_label = 'crm'
+        verbose_name = 'Приглашение в организацию'
+        verbose_name_plural = 'Приглашения в организации'
+
+    def save(self, *args, **kwargs):
+        if not self.token:
+            self.token = secrets.token_hex(16)
+        if not self.expires_at:
+            self.expires_at = timezone.now() + timedelta(days=7)
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return f"{self.email} -> {self.organization.name}"
+
 # Модели для управления проектами и задачами
 
 class Project(models.Model):
@@ -110,9 +236,9 @@ class Project(models.Model):
         ('high', 'Высокий'),
         ('urgent', 'Срочный'),
     ]
-    
     name = models.CharField(max_length=255, verbose_name='Название проекта')
     description = models.TextField(blank=True, verbose_name='Описание')
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name='projects', null=True, blank=True, verbose_name='Организация')
     owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name='owned_projects', verbose_name='Владелец проекта')
     manager = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True, related_name='managed_projects', verbose_name='Менеджер проекта')
     team_members = models.ManyToManyField(User, through='ProjectMember', related_name='project_teams', verbose_name='Участники команды')
@@ -205,8 +331,10 @@ class Task(models.Model):
     title = models.CharField(max_length=255, verbose_name='Название задачи')
     description = models.TextField(blank=True, verbose_name='Описание')
     project = models.ForeignKey(Project, on_delete=models.CASCADE, related_name='tasks', verbose_name='Проект')
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name='tasks', null=True, blank=True, verbose_name='Организация')
     assignee = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True, related_name='assigned_tasks', verbose_name='Исполнитель')
     creator = models.ForeignKey(User, on_delete=models.CASCADE, related_name='created_tasks', verbose_name='Создатель')
+    parent = models.ForeignKey('self', on_delete=models.CASCADE, null=True, blank=True, related_name='subtasks', verbose_name='Родительская задача')
     
     # Новые поля с внешними ключами
     status_ref = models.ForeignKey(TaskStatus, on_delete=models.SET_NULL, null=True, blank=True, related_name='tasks', verbose_name='Статус (новый)')

--- a/api/src/modules/crm/serializers.py
+++ b/api/src/modules/crm/serializers.py
@@ -2,7 +2,8 @@ from rest_framework import serializers
 from django.contrib.auth import get_user_model
 from .models import (
     Project, ProjectMember, Task, TaskComment, TaskAttachment, TimeLog,
-    ProjectStatus, ProjectPriority, TaskStatus, TaskPriority
+    ProjectStatus, ProjectPriority, TaskStatus, TaskPriority,
+    Organization, OrganizationMember, OrganizationInvite
 )
 
 User = get_user_model()
@@ -53,6 +54,45 @@ class CRMUserSerializer(serializers.ModelSerializer):
         fields = ['id', 'username', 'first_name', 'last_name', 'full_name', 'email']
 
 
+class OrganizationMemberSerializer(serializers.ModelSerializer):
+    """Сериализатор участника организации"""
+    user = CRMUserSerializer(read_only=True)
+    user_id = serializers.IntegerField(write_only=True, required=False)
+    invited_by = CRMUserSerializer(read_only=True)
+
+    class Meta:
+        model = OrganizationMember
+        fields = ['id', 'user', 'user_id', 'role', 'status', 'invited_by', 'invited_at', 'responded_at']
+        read_only_fields = ['invited_by', 'invited_at', 'responded_at']
+
+
+class OrganizationSerializer(serializers.ModelSerializer):
+    """Сериализатор организации"""
+    owner = CRMUserSerializer(read_only=True)
+    memberships = OrganizationMemberSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Organization
+        fields = [
+            'id', 'name', 'slug', 'description', 'logo_url', 'industry', 'website',
+            'email', 'phone', 'country', 'timezone', 'address',
+            'billing_name', 'billing_vat', 'billing_address',
+            'owner', 'memberships', 'visibility', 'default_role', 'status',
+            'created_at', 'updated_at'
+        ]
+        read_only_fields = ['slug', 'owner', 'created_at', 'updated_at']
+
+
+class OrganizationInviteSerializer(serializers.ModelSerializer):
+    """Сериализатор приглашения"""
+    organization = serializers.PrimaryKeyRelatedField(read_only=True)
+    invited_by = CRMUserSerializer(read_only=True)
+
+    class Meta:
+        model = OrganizationInvite
+        fields = ['id', 'organization', 'email', 'token', 'expires_at', 'status', 'invited_by', 'created_at']
+        read_only_fields = ['token', 'status', 'invited_by', 'created_at', 'organization']
+
 class ProjectMemberSerializer(serializers.ModelSerializer):
     """Сериализатор участника проекта"""
     user = CRMUserSerializer(read_only=True)
@@ -69,6 +109,8 @@ class ProjectSerializer(serializers.ModelSerializer):
     manager = CRMUserSerializer(read_only=True)
     manager_id = serializers.IntegerField(write_only=True, required=False, allow_null=True)
     memberships = ProjectMemberSerializer(many=True, read_only=True)
+    organization = OrganizationSerializer(read_only=True)
+    organization_id = serializers.IntegerField(write_only=True, required=False)
     
     # Новые поля для статусов и приоритетов
     status_ref = ProjectStatusSerializer(read_only=True)
@@ -90,7 +132,7 @@ class ProjectSerializer(serializers.ModelSerializer):
         model = Project
         fields = [
             'id', 'name', 'description', 'owner', 'manager', 'manager_id',
-            'memberships', 'status', 'priority', 'start_date', 'end_date',
+            'organization', 'organization_id', 'memberships', 'status', 'priority', 'start_date', 'end_date',
             'created_at', 'updated_at', 'color', 'task_count', 'completed_task_count',
             'progress', 'status_ref', 'priority_ref', 'status_ref_id', 'priority_ref_id',
             'current_status', 'current_priority', 'status_display', 'priority_display'
@@ -121,7 +163,20 @@ class ProjectSerializer(serializers.ModelSerializer):
         return round((completed / total) * 100)
     
     def create(self, validated_data):
-        validated_data['owner'] = self.context['request'].user
+        user = self.context['request'].user
+        organization_id = validated_data.pop('organization_id', None)
+        if not organization_id:
+            raise serializers.ValidationError('organization_id is required')
+        try:
+            organization = Organization.objects.get(id=organization_id)
+        except Organization.DoesNotExist:
+            raise serializers.ValidationError('Организация не найдена')
+
+        if not (organization.owner == user or OrganizationMember.objects.filter(organization=organization, user=user, status='accepted').exists()):
+            raise serializers.ValidationError('Вы не являетесь участником организации')
+
+        validated_data['owner'] = user
+        validated_data['organization'] = organization
         return super().create(validated_data)
 
 
@@ -129,6 +184,7 @@ class ProjectListSerializer(serializers.ModelSerializer):
     """Сериализатор списка проектов"""
     owner = CRMUserSerializer(read_only=True)
     manager = CRMUserSerializer(read_only=True)
+    organization = OrganizationSerializer(read_only=True)
     
     # Новые поля для статусов и приоритетов
     status_ref = ProjectStatusSerializer(read_only=True)
@@ -145,7 +201,7 @@ class ProjectListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Project
         fields = [
-            'id', 'name', 'description', 'owner', 'manager', 'status', 'priority',
+            'id', 'name', 'description', 'owner', 'manager', 'organization', 'status', 'priority',
             'start_date', 'end_date', 'created_at', 'color', 'task_count',
             'completed_task_count', 'progress', 'status_ref', 'priority_ref',
             'current_status', 'current_priority', 'status_display', 'priority_display'
@@ -215,6 +271,43 @@ class TimeLogSerializer(serializers.ModelSerializer):
         return super().create(validated_data)
 
 
+class TaskListSerializer(serializers.ModelSerializer):
+    """Сериализатор списка задач"""
+    assignee = CRMUserSerializer(read_only=True)
+    creator = CRMUserSerializer(read_only=True)
+    project = ProjectListSerializer(read_only=True)
+
+    # Новые поля для статусов и приоритетов
+    status_ref = TaskStatusSerializer(read_only=True)
+    priority_ref = TaskPrioritySerializer(read_only=True)
+    current_status = serializers.CharField(read_only=True)
+    current_priority = serializers.CharField(read_only=True)
+    status_display = serializers.CharField(read_only=True)
+    priority_display = serializers.CharField(read_only=True)
+
+    parent = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    comment_count = serializers.SerializerMethodField()
+    attachment_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Task
+        fields = [
+            'id', 'title', 'description', 'project', 'assignee', 'creator',
+            'status', 'priority', 'start_date', 'due_date', 'completed_at',
+            'created_at', 'updated_at', 'estimated_hours', 'actual_hours',
+            'kanban_order', 'comment_count', 'attachment_count',
+            'status_ref', 'priority_ref', 'current_status', 'current_priority',
+            'status_display', 'priority_display', 'parent'
+        ]
+
+    def get_comment_count(self, obj):
+        return obj.comments.count()
+
+    def get_attachment_count(self, obj):
+        return obj.attachments.count()
+
+
 class TaskSerializer(serializers.ModelSerializer):
     """Сериализатор задачи"""
     assignee = CRMUserSerializer(read_only=True)
@@ -222,6 +315,11 @@ class TaskSerializer(serializers.ModelSerializer):
     project = ProjectListSerializer(read_only=True)
     assignee_id = serializers.IntegerField(write_only=True, required=False, allow_null=True)
     project_id = serializers.IntegerField(write_only=True)
+    organization = OrganizationSerializer(read_only=True)
+    organization_id = serializers.IntegerField(write_only=True)
+    parent = TaskListSerializer(read_only=True)
+    parent_id = serializers.IntegerField(write_only=True, required=False, allow_null=True)
+    subtasks = TaskListSerializer(many=True, read_only=True)
     
     # Новые поля для статусов и приоритетов
     status_ref = TaskStatusSerializer(read_only=True)
@@ -247,10 +345,10 @@ class TaskSerializer(serializers.ModelSerializer):
     class Meta:
         model = Task
         fields = [
-            'id', 'title', 'description', 'project', 'project_id', 'assignee', 'assignee_id',
+            'id', 'title', 'description', 'project', 'project_id', 'organization', 'organization_id', 'assignee', 'assignee_id',
             'creator', 'status', 'priority', 'start_date', 'due_date', 'completed_at',
             'created_at', 'updated_at', 'estimated_hours', 'actual_hours', 'kanban_order',
-            'comments', 'attachments', 'time_logs', 'total_time',
+            'comments', 'attachments', 'time_logs', 'total_time', 'parent', 'parent_id', 'subtasks',
             'status_ref', 'priority_ref', 'status_ref_id', 'priority_ref_id',
             'current_status', 'current_priority', 'status_display', 'priority_display'
         ]
@@ -270,43 +368,28 @@ class TaskSerializer(serializers.ModelSerializer):
         return data
     
     def create(self, validated_data):
-        validated_data['creator'] = self.context['request'].user
+        user = self.context['request'].user
+        organization_id = validated_data.pop('organization_id', None)
+        if not organization_id:
+            raise serializers.ValidationError('organization_id is required')
+        try:
+            organization = Organization.objects.get(id=organization_id)
+        except Organization.DoesNotExist:
+            raise serializers.ValidationError('Организация не найдена')
+        if not (organization.owner == user or OrganizationMember.objects.filter(organization=organization, user=user, status='accepted').exists()):
+            raise serializers.ValidationError('Вы не являетесь участником организации')
+
+        project_id = validated_data.pop('project_id', None)
+        try:
+            project = Project.objects.get(id=project_id, organization=organization)
+        except Project.DoesNotExist:
+            raise serializers.ValidationError('Проект не найден в организации')
+
+        validated_data['project'] = project
+        validated_data['creator'] = user
+        validated_data['organization'] = organization
         return super().create(validated_data)
 
-
-class TaskListSerializer(serializers.ModelSerializer):
-    """Сериализатор списка задач"""
-    assignee = CRMUserSerializer(read_only=True)
-    creator = CRMUserSerializer(read_only=True)
-    project = ProjectListSerializer(read_only=True)
-    
-    # Новые поля для статусов и приоритетов
-    status_ref = TaskStatusSerializer(read_only=True)
-    priority_ref = TaskPrioritySerializer(read_only=True)
-    current_status = serializers.CharField(read_only=True)
-    current_priority = serializers.CharField(read_only=True)
-    status_display = serializers.CharField(read_only=True)
-    priority_display = serializers.CharField(read_only=True)
-    
-    comment_count = serializers.SerializerMethodField()
-    attachment_count = serializers.SerializerMethodField()
-    
-    class Meta:
-        model = Task
-        fields = [
-            'id', 'title', 'description', 'project', 'assignee', 'creator',
-            'status', 'priority', 'start_date', 'due_date', 'completed_at',
-            'created_at', 'updated_at', 'estimated_hours', 'actual_hours',
-            'kanban_order', 'comment_count', 'attachment_count',
-            'status_ref', 'priority_ref', 'current_status', 'current_priority',
-            'status_display', 'priority_display'
-        ]
-    
-    def get_comment_count(self, obj):
-        return obj.comments.count()
-    
-    def get_attachment_count(self, obj):
-        return obj.attachments.count()
 
 
 class TaskCalendarSerializer(serializers.ModelSerializer):

--- a/api/src/modules/crm/urls.py
+++ b/api/src/modules/crm/urls.py
@@ -2,7 +2,8 @@ from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .views import (
     ProjectViewSet, TaskViewSet, TaskCommentViewSet, TimeLogViewSet, UserViewSet,
-    ProjectStatusViewSet, ProjectPriorityViewSet, TaskStatusViewSet, TaskPriorityViewSet
+    ProjectStatusViewSet, ProjectPriorityViewSet, TaskStatusViewSet, TaskPriorityViewSet,
+    OrganizationViewSet, OrganizationInviteViewSet
 )
 
 router = DefaultRouter()
@@ -17,6 +18,8 @@ router.register(r'project-statuses', ProjectStatusViewSet)
 router.register(r'project-priorities', ProjectPriorityViewSet)
 router.register(r'task-statuses', TaskStatusViewSet)
 router.register(r'task-priorities', TaskPriorityViewSet)
+router.register(r'organizations', OrganizationViewSet)
+router.register(r'invites', OrganizationInviteViewSet, basename='organization-invite')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/api/src/modules/crm/views.py
+++ b/api/src/modules/crm/views.py
@@ -13,16 +13,120 @@ from src.core.utils.mixins import SwaggerSafeMixin
 
 from .models import (
     Project, ProjectMember, Task, TaskComment, TaskAttachment, TimeLog,
-    ProjectStatus, ProjectPriority, TaskStatus, TaskPriority
+    ProjectStatus, ProjectPriority, TaskStatus, TaskPriority,
+    Organization, OrganizationMember, OrganizationInvite
 )
 from .serializers import (
     ProjectSerializer, ProjectListSerializer, ProjectMemberSerializer,
     TaskSerializer, TaskListSerializer, TaskCalendarSerializer, TaskKanbanSerializer,
     TaskCommentSerializer, TaskAttachmentSerializer, TimeLogSerializer, CRMUserSerializer,
-    ProjectStatusSerializer, ProjectPrioritySerializer, TaskStatusSerializer, TaskPrioritySerializer
+    ProjectStatusSerializer, ProjectPrioritySerializer, TaskStatusSerializer, TaskPrioritySerializer,
+    OrganizationSerializer, OrganizationMemberSerializer, OrganizationInviteSerializer
 )
 
 User = get_user_model()
+
+
+class OrganizationViewSet(viewsets.ModelViewSet):
+    """ViewSet для управления организациями"""
+    queryset = Organization.objects.all()
+    serializer_class = OrganizationSerializer
+    permission_classes = [IsAuthenticated]
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ['name']
+    ordering_fields = ['name', 'created_at']
+    ordering = ['name']
+
+    def get_queryset(self):
+        user = self.request.user
+        return Organization.objects.filter(
+            Q(owner=user) | Q(memberships__user=user, memberships__status='accepted')
+        ).distinct()
+
+    def perform_create(self, serializer):
+        organization = serializer.save(owner=self.request.user)
+        OrganizationMember.objects.create(
+            organization=organization,
+            user=self.request.user,
+            role='owner',
+            status='accepted',
+            invited_by=self.request.user,
+            invited_at=timezone.now(),
+            responded_at=timezone.now()
+        )
+
+    @action(detail=True, methods=['post'])
+    def invite(self, request, pk=None):
+        """Пригласить пользователя в организацию"""
+        organization = self.get_object()
+        email = request.data.get('email')
+        role = request.data.get('role', organization.default_role)
+        if not email:
+            return Response({'error': 'email is required'}, status=status.HTTP_400_BAD_REQUEST)
+        invite = OrganizationInvite.objects.create(
+            organization=organization,
+            email=email,
+            invited_by=request.user,
+        )
+        return Response({'token': invite.token, 'status': invite.status}, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['get'])
+    def members(self, request, pk=None):
+        """Список участников организации"""
+        organization = self.get_object()
+        if not (organization.owner == request.user or OrganizationMember.objects.filter(organization=organization, user=request.user, role__in=['owner', 'admin'], status='accepted').exists()):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+        serializer = OrganizationMemberSerializer(organization.memberships.all(), many=True)
+        return Response(serializer.data)
+
+
+class OrganizationInviteViewSet(viewsets.ViewSet):
+    """ViewSet для приглашений в организации"""
+    permission_classes = [IsAuthenticated]
+
+    def list(self, request):
+        invites = OrganizationInvite.objects.filter(
+            email=request.user.email, status='pending'
+        ).filter(Q(expires_at__isnull=True) | Q(expires_at__gt=timezone.now()))
+        serializer = OrganizationInviteSerializer(invites, many=True)
+        return Response(serializer.data)
+
+    @action(detail=False, methods=['post'])
+    def accept(self, request):
+        token = request.data.get('token')
+        try:
+            invite = OrganizationInvite.objects.get(token=token, email=request.user.email)
+        except OrganizationInvite.DoesNotExist:
+            return Response({'error': 'Инвайт не найден'}, status=status.HTTP_404_NOT_FOUND)
+        if invite.expires_at and invite.expires_at < timezone.now():
+            invite.status = 'expired'
+            invite.save()
+            return Response({'error': 'Инвайт просрочен'}, status=status.HTTP_410_GONE)
+        invite.status = 'accepted'
+        invite.responded_at = timezone.now()
+        invite.save()
+        OrganizationMember.objects.create(
+            organization=invite.organization,
+            user=request.user,
+            role=invite.organization.default_role,
+            status='accepted',
+            invited_by=invite.invited_by,
+            invited_at=invite.created_at,
+            responded_at=timezone.now()
+        )
+        return Response({'status': 'accepted'})
+
+    @action(detail=False, methods=['post'])
+    def decline(self, request):
+        token = request.data.get('token')
+        try:
+            invite = OrganizationInvite.objects.get(token=token, email=request.user.email)
+        except OrganizationInvite.DoesNotExist:
+            return Response({'error': 'Инвайт не найден'}, status=status.HTTP_404_NOT_FOUND)
+        invite.status = 'declined'
+        invite.responded_at = timezone.now()
+        invite.save()
+        return Response({'status': 'declined'})
 
 
 class ProjectStatusViewSet(viewsets.ModelViewSet):
@@ -168,12 +272,15 @@ class ProjectViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
             return Project.objects.none()
             
         queryset = super().get_queryset()
-        
-        # По умолчанию показываем только проекты, в которых пользователь участвует
-        # Это включает: владельца, менеджера и участников команды
+
+        # Показываем только проекты организаций, где пользователь является владельцем
+        # или принятым участником
         queryset = queryset.filter(
-            Q(owner=user) | 
-            Q(manager=user) | 
+            Q(organization__owner=user) |
+            Q(organization__memberships__user=user, organization__memberships__status='accepted')
+        ).filter(
+            Q(owner=user) |
+            Q(manager=user) |
             Q(team_members=user)
         ).distinct()
         
@@ -267,7 +374,7 @@ class TaskViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
     queryset = Task.objects.all()
     permission_classes = [IsAuthenticated]
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
-    filterset_fields = ['status', 'priority', 'project', 'assignee', 'creator']
+    filterset_fields = ['status', 'priority', 'project', 'assignee', 'creator', 'parent']
     search_fields = ['title', 'description']
     ordering_fields = ['created_at', 'due_date', 'priority', 'kanban_order']
     ordering = ['kanban_order', '-created_at']
@@ -290,17 +397,22 @@ class TaskViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
             return Task.objects.none()
             
         queryset = super().get_queryset()
-        
-        # Параметр "Мои задачи" 
+
+        # Ограничиваем задачи организациями, где пользователь владелец
+        # или принятый участник
+        queryset = queryset.filter(
+            Q(organization__owner=user) |
+            Q(organization__memberships__user=user, organization__memberships__status='accepted')
+        )
+
+        # Параметр "Мои задачи"
         my_tasks = self.request.query_params.get('my_tasks', None)
-        
+
         if my_tasks and my_tasks.lower() == 'true':
             # Только мои задачи - только задачи, где я исполнитель
             queryset = queryset.filter(assignee=user).distinct()
         else:
             # Показываем все задачи из проектов, в которых пользователь участвует
-            # Это включает: владельца проекта, менеджера проекта, участников команды, 
-            # исполнителей задач и создателей задач
             queryset = queryset.filter(
                 Q(project__owner=user) |
                 Q(project__manager=user) |

--- a/client/src/config/routes-config.json
+++ b/client/src/config/routes-config.json
@@ -557,6 +557,23 @@
         "requiresAuth": true
       }
     },
+    "Organizations": {
+      "path": "/crm/organizations",
+      "component": "@/modules/crm/project-management/Organizations.vue",
+      "meta": {
+        "title": "Организации",
+        "requiresAuth": true
+      }
+    },
+
+    "OrganizationInvites": {
+      "path": "/crm/invites",
+      "component": "@/modules/crm/project-management/OrganizationInvites.vue",
+      "meta": {
+        "title": "Приглашения",
+        "requiresAuth": true
+      }
+    },
 
     "LMS": {
       "path": "/lms",

--- a/client/src/modules/crm/project-management/OrganizationInvites.vue
+++ b/client/src/modules/crm/project-management/OrganizationInvites.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="org-invites">
+    <h2>Приглашения</h2>
+    <ul>
+      <li v-for="invite in invites" :key="invite.id">
+        {{ invite.organization }}
+        <button @click="accept(invite.token)">Принять</button>
+        <button @click="decline(invite.token)">Отклонить</button>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+import { ref, onMounted } from 'vue';
+import ProjectManagementApi from './js/projectManagementApi';
+
+export default {
+  name: 'OrganizationInvites',
+  setup() {
+    const invites = ref([]);
+
+    const load = async () => {
+      const resp = await ProjectManagementApi.getInvites();
+      invites.value = resp.data;
+    };
+
+    const accept = async (token) => {
+      await ProjectManagementApi.acceptInvite(token);
+      await load();
+    };
+
+    const decline = async (token) => {
+      await ProjectManagementApi.declineInvite(token);
+      await load();
+    };
+
+    onMounted(load);
+
+    return { invites, accept, decline };
+  }
+};
+</script>
+
+<style scoped>
+.org-invites ul {
+  list-style: none;
+  padding: 0;
+}
+.org-invites li {
+  margin-bottom: 8px;
+}
+</style>

--- a/client/src/modules/crm/project-management/Organizations.vue
+++ b/client/src/modules/crm/project-management/Organizations.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="organizations-page">
+    <div class="tabs mb-3">
+      <button @click="active = 'list'" :class="{ active: active === 'list' }">Организации</button>
+      <button @click="active = 'invites'" :class="{ active: active === 'invites' }">Приглашения</button>
+    </div>
+    <OrganizationsList v-if="active === 'list'" />
+    <OrganizationInvites v-else />
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+import OrganizationsList from './OrganizationsList.vue';
+import OrganizationInvites from './OrganizationInvites.vue';
+
+export default {
+  name: 'Organizations',
+  components: { OrganizationsList, OrganizationInvites },
+  setup() {
+    const active = ref('list');
+    return { active };
+  }
+};
+</script>
+
+<style scoped>
+.tabs button {
+  margin-right: 8px;
+}
+.tabs button.active {
+  font-weight: bold;
+}
+</style>
+

--- a/client/src/modules/crm/project-management/OrganizationsList.vue
+++ b/client/src/modules/crm/project-management/OrganizationsList.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="organizations-list">
+    <h2>Организации</h2>
+    <form @submit.prevent="createOrganization" class="mb-3">
+      <input v-model="newOrg" placeholder="Название организации" />
+      <button type="submit">Создать</button>
+    </form>
+    <ul>
+      <li v-for="org in organizations" :key="org.id">
+        <div v-if="editingId === org.id">
+          <input v-model="editName" />
+          <button @click="saveEdit(org.id)">Сохранить</button>
+          <button @click="cancelEdit">Отмена</button>
+        </div>
+        <div v-else>
+          {{ org.name }}
+          <span v-if="org.owner && org.owner.id === userId">(владелец)</span>
+          <button v-if="org.owner && org.owner.id === userId" @click="startEdit(org)">Редактировать</button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+import { ref, onMounted } from 'vue';
+import { useStore } from 'vuex';
+import ProjectManagementApi from './js/projectManagementApi';
+
+export default {
+  name: 'OrganizationsList',
+  setup() {
+    const store = useStore();
+    const organizations = ref([]);
+    const newOrg = ref('');
+    const userId = store.state?.auth?.user?.id;
+    const editingId = ref(null);
+    const editName = ref('');
+
+    const load = async () => {
+      const resp = await ProjectManagementApi.getOrganizations();
+      organizations.value = resp.data.results || resp.data;
+    };
+
+    const createOrganization = async () => {
+      if (!newOrg.value) return;
+      await ProjectManagementApi.createOrganization({ name: newOrg.value });
+      newOrg.value = '';
+      await load();
+    };
+
+    const startEdit = (org) => {
+      editingId.value = org.id;
+      editName.value = org.name;
+    };
+
+    const cancelEdit = () => {
+      editingId.value = null;
+    };
+
+    const saveEdit = async (orgId) => {
+      await ProjectManagementApi.updateOrganization(orgId, { name: editName.value });
+      editingId.value = null;
+      await load();
+    };
+
+    onMounted(load);
+
+    return { organizations, newOrg, createOrganization, userId, editingId, editName, startEdit, cancelEdit, saveEdit };
+  }
+};
+</script>
+
+<style scoped>
+.organizations-list input {
+  margin-right: 8px;
+}
+</style>
+

--- a/client/src/modules/crm/project-management/ProjectDetail.vue
+++ b/client/src/modules/crm/project-management/ProjectDetail.vue
@@ -238,10 +238,17 @@
             <ListTodo :size="24" />
             <h2>Задачи проекта</h2>
           </div>
-          <button class="btn btn-primary" @click="createTask">
-            <Plus :size="16" />
-            <span>Добавить задачу</span>
-          </button>
+          <div class="section-actions">
+            <button class="btn btn-outline-primary" @click="toggleTaskView">
+              <GitBranch :size="16" v-if="!showTaskTree" />
+              <ListTodo :size="16" v-else />
+              <span>{{ showTaskTree ? 'Список' : 'Дерево' }}</span>
+            </button>
+            <button class="btn btn-primary" @click="createTask">
+              <Plus :size="16" />
+              <span>Добавить задачу</span>
+            </button>
+          </div>
         </div>
         
         <div class="tasks-content">
@@ -256,68 +263,76 @@
             </button>
           </div>
           
-          <!-- Таблица задач -->
-          <div v-else class="tasks-table-container">
-            <div class="table-responsive">
-              <table class="tasks-table">
-                <thead>
-                  <tr>
-                    <th>Задача</th>
-                    <th>Исполнитель</th>
-                    <th>Статус</th>
-                    <th>Приоритет</th>
-                    <th>Срок</th>
-                    <th>Действия</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="task in tasks" :key="task.id" class="task-row">
-                    <td class="task-cell">
-                      <div class="task-info">
-                        <h4 class="task-title">{{ task.title }}</h4>
-                        <p class="task-description" v-if="task.description">
-                          {{ truncateText(task.description, 100) }}
-                        </p>
-                      </div>
-                    </td>
-                    <td class="assignee-cell">
-                      <div class="assignee-info" v-if="task.assignee">
-                        <img :src="getAvatarUrl(task.assignee)" 
-                             :alt="getUserDisplayName(task.assignee)"
-                             class="assignee-avatar">
-                        <span class="assignee-name">{{ getUserDisplayName(task.assignee) }}</span>
-                      </div>
-                      <span v-else class="no-assignee">Не назначен</span>
-                    </td>
-                    <td class="status-cell">
-                      <span class="badge status-badge" :class="getTaskStatusClass(task.status)">
-                        {{ getTaskStatusText(task.status) }}
-                      </span>
-                    </td>
-                    <td class="priority-cell">
-                      <span class="badge priority-badge" :class="getPriorityClass(task.priority)">
-                        {{ getPriorityText(task.priority) }}
-                      </span>
-                    </td>
-                    <td class="due-date-cell">
-                      <span :class="getDueDateClass(task.due_date, task.status)">
-                        <Clock :size="14" />
-                        {{ formatDate(task.due_date) || '-' }}
-                      </span>
-                    </td>
-                    <td class="actions-cell">
-                      <div class="action-buttons">
-                        <button class="btn btn-edit-icon" @click="editTask(task)" title="Редактировать">
-                          <Edit :size="14" />
-                        </button>
-                        <button class="btn btn-delete-icon" @click="deleteTask(task)" title="Удалить">
-                          <Trash2 :size="14" />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+          <!-- Таблица задач или дерево -->
+          <div v-else>
+            <div v-if="showTaskTree" class="task-tree-container">
+              <ProjectTasksTree :project="project" :tasks="tasks" />
+            </div>
+            <div v-else class="tasks-table-container">
+              <div class="table-responsive">
+                <table class="tasks-table">
+                  <thead>
+                    <tr>
+                      <th>Задача</th>
+                      <th>Исполнитель</th>
+                      <th>Статус</th>
+                      <th>Приоритет</th>
+                      <th>Срок</th>
+                      <th>Действия</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="task in tasks" :key="task.id" class="task-row">
+                      <td class="task-cell">
+                        <div class="task-info">
+                          <h4 class="task-title">{{ task.title }}</h4>
+                          <p class="task-description" v-if="task.description">
+                            {{ truncateText(task.description, 100) }}
+                          </p>
+                        </div>
+                      </td>
+                      <td class="assignee-cell">
+                        <div class="assignee-info" v-if="task.assignee">
+                          <img :src="getAvatarUrl(task.assignee)"
+                               :alt="getUserDisplayName(task.assignee)"
+                               class="assignee-avatar">
+                          <span class="assignee-name">{{ getUserDisplayName(task.assignee) }}</span>
+                        </div>
+                        <span v-else class="no-assignee">Не назначен</span>
+                      </td>
+                      <td class="status-cell">
+                        <span class="badge status-badge" :class="getTaskStatusClass(task.status)">
+                          {{ getTaskStatusText(task.status) }}
+                        </span>
+                      </td>
+                      <td class="priority-cell">
+                        <span class="badge priority-badge" :class="getPriorityClass(task.priority)">
+                          {{ getPriorityText(task.priority) }}
+                        </span>
+                      </td>
+                      <td class="due-date-cell">
+                        <span :class="getDueDateClass(task.due_date, task.status)">
+                          <Clock :size="14" />
+                          {{ formatDate(task.due_date) || '-' }}
+                        </span>
+                      </td>
+                      <td class="actions-cell">
+                        <div class="action-buttons">
+                          <button class="btn btn-edit-icon" @click="createSubTask(task)" title="Добавить подзадачу">
+                            <Plus :size="14" />
+                          </button>
+                          <button class="btn btn-edit-icon" @click="editTask(task)" title="Редактировать">
+                            <Edit :size="14" />
+                          </button>
+                          <button class="btn btn-delete-icon" @click="deleteTask(task)" title="Удалить">
+                            <Trash2 :size="14" />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </div>
           </div>
         </div>
@@ -593,10 +608,11 @@
 
 <script>
 import { Modal } from 'bootstrap'
-import { Edit, Trash2, Plus, Home, Info, PieChart, ListTodo, Calendar, Clock, Users, CheckCircle, AlertTriangle, UserPlus, UserMinus } from 'lucide-vue-next'
+import { Edit, Trash2, Plus, Home, Info, PieChart, ListTodo, Calendar, Clock, Users, CheckCircle, AlertTriangle, UserPlus, UserMinus, GitBranch } from 'lucide-vue-next'
 import projectManagementApi from '@/modules/crm/project-management/js/projectManagementApi.js'
 import { useNotifications } from '@/modules/lms/composables/useNotifications'
 import { getAvatarUrl } from '@/modules/cms/js/avatarUtils.js'
+import ProjectTasksTree from './ProjectTasksTree.vue'
 
 export default {
   name: 'ProjectDetail',
@@ -614,7 +630,9 @@ export default {
     CheckCircle,
     AlertTriangle,
     UserPlus,
-    UserMinus
+    UserMinus,
+    GitBranch,
+    ProjectTasksTree
   },
   setup() {
     const { showSuccess, showError, showConfirmDialog, closeConfirmDialog } = useNotifications()
@@ -626,6 +644,7 @@ export default {
       error: null,
       project: null,
       tasks: [],
+      showTaskTree: false,
       users: [],
       currentTask: {
         title: '',
@@ -635,7 +654,8 @@ export default {
         priority: 'medium',
         start_date: '',
         due_date: '',
-        estimated_hours: null
+        estimated_hours: null,
+        parent_id: null
       },
       currentProject: {
         name: '',
@@ -813,6 +833,9 @@ export default {
     }
   },
   methods: {
+    toggleTaskView() {
+      this.showTaskTree = !this.showTaskTree
+    },
     async loadProjectData() {
       const projectId = this.$route.params.id
       if (!projectId) {
@@ -934,13 +957,13 @@ export default {
       modal.show()
     },
 
-    createTask() {
+    createTask(parentTask = null) {
       if (!this.project) return
-      
+
       // Устанавливаем значения по умолчанию из загруженных данных
       const defaultTaskStatus = this.taskStatuses.find(s => s.is_default) || this.taskStatuses[0]
       const defaultTaskPriority = this.taskPriorities.find(p => p.is_default) || this.taskPriorities[0]
-      
+
       this.isEditingTask = false
       this.currentTask = {
         title: '',
@@ -951,11 +974,16 @@ export default {
         priority: defaultTaskPriority ? defaultTaskPriority.code : 'medium',
         start_date: '',
         due_date: '',
-        estimated_hours: null
+        estimated_hours: null,
+        parent_id: parentTask ? parentTask.id : null
       }
-      
+
       const modal = new Modal(document.getElementById('taskModal'))
       modal.show()
+    },
+
+    createSubTask(task) {
+      this.createTask(task)
     },
 
     editTask(task) {
@@ -970,9 +998,10 @@ export default {
         priority: task.priority,
         start_date: task.start_date ? this.formatDateTimeLocal(new Date(task.start_date)) : '',
         due_date: task.due_date ? this.formatDateTimeLocal(new Date(task.due_date)) : '',
-        estimated_hours: task.estimated_hours
+        estimated_hours: task.estimated_hours,
+        parent_id: task.parent || null
       }
-      
+
       const modal = new Modal(document.getElementById('taskModal'))
       modal.show()
     },
@@ -1038,7 +1067,8 @@ export default {
           assignee_id: this.currentTask.assignee_id || null,
           start_date: this.currentTask.start_date || null,
           due_date: this.currentTask.due_date || null,
-          estimated_hours: this.currentTask.estimated_hours || null
+          estimated_hours: this.currentTask.estimated_hours || null,
+          parent_id: this.currentTask.parent_id || null
         }
         
         if (this.isEditingTask) {
@@ -1950,7 +1980,12 @@ export default {
         margin: 0;
       }
     }
-    
+
+    .section-actions {
+      display: flex;
+      gap: 0.75rem;
+    }
+
     .btn {
       display: flex;
       align-items: center;
@@ -1969,7 +2004,7 @@ export default {
   
   .tasks-content {
     padding: 1.5rem;
-    
+
     .empty-state {
       text-align: center;
       padding: 3rem 2rem;
@@ -1997,6 +2032,10 @@ export default {
         font-weight: 600;
         border-radius: 8px;
       }
+    }
+
+    .task-tree-container {
+      height: 400px;
     }
   }
 }

--- a/client/src/modules/crm/project-management/ProjectTasksTree.vue
+++ b/client/src/modules/crm/project-management/ProjectTasksTree.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="task-tree">
+    <VueFlow :nodes="nodes" :edges="edges" fit-view :zoom-on-scroll="false" :nodes-connectable="false" :edges-connectable="false" />
+  </div>
+</template>
+
+<script setup>
+import '@vue-flow/core/dist/style.css'
+import '@vue-flow/core/dist/theme-default.css'
+import { ref, watch } from 'vue'
+import { VueFlow } from '@vue-flow/core'
+
+const props = defineProps({
+  project: { type: Object, required: true },
+  tasks: { type: Array, default: () => [] }
+})
+
+const nodes = ref([])
+const edges = ref([])
+
+function buildGraph() {
+  const rootId = `project-${props.project.id}`
+  nodes.value = [
+    {
+      id: rootId,
+      data: { label: props.project.name },
+      position: { x: 0, y: 0 },
+      draggable: false,
+      type: 'input'
+    }
+  ]
+  edges.value = []
+
+  const tasksByParent = {}
+  props.tasks.forEach(task => {
+    const parentId = task.parent || null
+    if (!tasksByParent[parentId]) tasksByParent[parentId] = []
+    tasksByParent[parentId].push(task)
+  })
+
+  const levelSpacing = 150
+  const nodeSpacing = 180
+
+  function addChildren(parentId, tasks, depth, startX) {
+    tasks.forEach((task, index) => {
+      const nodeId = `task-${task.id}`
+      const x = startX + index * nodeSpacing
+      const y = depth * levelSpacing
+      nodes.value.push({
+        id: nodeId,
+        data: { label: task.title },
+        position: { x, y },
+        draggable: false
+      })
+      edges.value.push({
+        id: `edge-${parentId || 'root'}-${task.id}`,
+        source: parentId ? `task-${parentId}` : rootId,
+        target: nodeId
+      })
+      const children = tasksByParent[task.id]
+      if (children && children.length) {
+        addChildren(task.id, children, depth + 1, x)
+      }
+    })
+  }
+
+  addChildren(null, tasksByParent[null] || [], 1, 0)
+}
+
+watch(() => props.tasks, buildGraph, { immediate: true })
+watch(() => props.project, buildGraph)
+</script>
+
+<style scoped>
+.task-tree {
+  width: 100%;
+  height: 100%;
+}
+</style>
+

--- a/client/src/modules/crm/project-management/TasksList.vue
+++ b/client/src/modules/crm/project-management/TasksList.vue
@@ -174,6 +174,9 @@
                 </td>
                 <td @click.stop class="actions-cell">
                   <div class="action-buttons">
+                    <button class="btn btn-edit-icon" @click="createSubTask(task)" title="Добавить подзадачу">
+                      <Plus />
+                    </button>
                     <button class="btn btn-edit-icon" @click="editTask(task)" title="Редактировать">
                       <Edit />
                     </button>
@@ -497,7 +500,7 @@
 
 <script>
 import { Modal } from 'bootstrap'
-import { Edit, Trash2 } from 'lucide-vue-next'
+import { Edit, Trash2, Plus } from 'lucide-vue-next'
 import projectManagementApi from '@/modules/crm/project-management/js/projectManagementApi.js'
 import { useNotifications } from '@/modules/lms/composables/useNotifications'
 import { getAvatarUrl } from '@/modules/cms/js/avatarUtils.js'
@@ -506,7 +509,8 @@ export default {
   name: 'TasksList',
   components: {
     Edit,
-    Trash2
+    Trash2,
+    Plus
   },
   props: {
     managementMode: {
@@ -549,7 +553,8 @@ export default {
         priority: 'medium',
         start_date: '',
         due_date: '',
-        estimated_hours: null
+        estimated_hours: null,
+        parent_id: null
       },
       selectedTask: {},
       isEditing: false,
@@ -739,31 +744,36 @@ export default {
       console.log('Статусы и приоритеты задач обновлены:', this.taskStatuses.length, this.taskPriorities.length)
     },
     
-    async createTask() {
+    async createTask(parentTask = null) {
       this.isEditing = false
-      
+
       // Обновляем статусы и приоритеты перед созданием задачи
       console.log('Обновляем статусы перед созданием задачи...')
       await this.refreshStatusesAndPriorities()
-      
+
       // Устанавливаем значения по умолчанию из загруженных данных
       const defaultStatus = this.taskStatuses.find(s => s.is_default) || this.taskStatuses[0]
       const defaultPriority = this.taskPriorities.find(p => p.is_default) || this.taskPriorities[0]
-      
+
       this.currentTask = {
         title: '',
         description: '',
-        project_id: '',
+        project_id: parentTask?.project?.id || '',
         assignee_id: '',
         status: defaultStatus ? defaultStatus.code : 'todo',
         priority: defaultPriority ? defaultPriority.code : 'medium',
         start_date: '',
         due_date: '',
-        estimated_hours: null
+        estimated_hours: null,
+        parent_id: parentTask ? parentTask.id : null
       }
-      
+
       const modal = new Modal(document.getElementById('taskModal'))
       modal.show()
+    },
+
+    createSubTask(task) {
+      this.createTask(task)
     },
     
     editTask(task) {
@@ -778,7 +788,8 @@ export default {
         priority: task.priority,
         start_date: task.start_date ? this.formatDateTimeLocal(new Date(task.start_date)) : '',
         due_date: task.due_date ? this.formatDateTimeLocal(new Date(task.due_date)) : '',
-        estimated_hours: task.estimated_hours
+        estimated_hours: task.estimated_hours,
+        parent_id: task.parent || null
       }
       
       const modal = new Modal(document.getElementById('taskModal'))
@@ -808,7 +819,8 @@ export default {
           assignee_id: this.currentTask.assignee_id || null,
           start_date: this.currentTask.start_date || null,
           due_date: this.currentTask.due_date || null,
-          estimated_hours: this.currentTask.estimated_hours || null
+          estimated_hours: this.currentTask.estimated_hours || null,
+          parent_id: this.currentTask.parent_id || null
         }
         
         if (this.isEditing) {

--- a/client/src/modules/crm/project-management/js/projectManagementApi.js
+++ b/client/src/modules/crm/project-management/js/projectManagementApi.js
@@ -160,6 +160,35 @@ class ProjectManagementApi {
         return await this.client.get('/crm/users/', { params });
     }
 
+    // ОРГАНИЗАЦИИ
+    async getOrganizations() {
+        return await this.client.get('/crm/organizations/');
+    }
+
+    async createOrganization(data) {
+        return await this.client.post('/crm/organizations/', data);
+    }
+
+    async updateOrganization(id, data) {
+        return await this.client.patch(`/crm/organizations/${id}/`, data);
+    }
+
+    async inviteToOrganization(orgId, data) {
+        return await this.client.post(`/crm/organizations/${orgId}/invite/`, data);
+    }
+
+    async getInvites() {
+        return await this.client.get('/crm/invites/');
+    }
+
+    async acceptInvite(token) {
+        return await this.client.post('/crm/invites/accept/', { token });
+    }
+
+    async declineInvite(token) {
+        return await this.client.post('/crm/invites/decline/', { token });
+    }
+
     // ВСПОМОГАТЕЛЬНЫЕ МЕТОДЫ
     async uploadFile(file, taskId = null) {
         const formData = new FormData();


### PR DESCRIPTION
## Summary
- add ProjectTasksTree component using VueFlow to render tasks graphically
- allow toggling between table and tree view on project detail page
- add nested subtask support across backend and UI
- introduce organizations with membership confirmation and scope projects and tasks by organization
- provide organization management API, Vue list view, and routing
- add invitation model and endpoints with Vue invites page
- add unified organizations page with editing and invitation tabs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 371 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68968e3efc7c832990a3404bcb41a86c