### PR TITLE
Support roles in organization invites

### DIFF
--- a/api/src/modules/crm/migrations/0009_organizationinvite_role.py
+++ b/api/src/modules/crm/migrations/0009_organizationinvite_role.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('crm', '0008_alter_organization_id_alter_organization_members_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='organizationinvite',
+            name='role',
+            field=models.CharField(
+                choices=[('owner','owner'),('admin','admin'),('member','member'),('viewer','viewer')],
+                default='member',
+                max_length=20,
+                verbose_name='\u0420\u043e\u043b\u044c',
+            ),
+        ),
+    ]

--- a/api/src/modules/crm/models.py
+++ b/api/src/modules/crm/models.py
@@ -200,6 +200,12 @@ class OrganizationInvite(models.Model):
 
     organization = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name='invites')
     email = models.EmailField(verbose_name='Email')
+    role = models.CharField(
+        max_length=20,
+        choices=OrganizationMember.ROLE_CHOICES,
+        default='member',
+        verbose_name='Роль'
+    )
     token = models.CharField(max_length=64, unique=True, editable=False)
     expires_at = models.DateTimeField(null=True, blank=True, verbose_name='Истекает')
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='pending', verbose_name='Статус')

--- a/api/src/modules/crm/serializers.py
+++ b/api/src/modules/crm/serializers.py
@@ -84,12 +84,15 @@ class OrganizationSerializer(serializers.ModelSerializer):
 
 class OrganizationInviteSerializer(serializers.ModelSerializer):
     """Сериализатор приглашения"""
-    organization = serializers.PrimaryKeyRelatedField(read_only=True)
+    organization = OrganizationSerializer(read_only=True)
     invited_by = CRMUserSerializer(read_only=True)
 
     class Meta:
         model = OrganizationInvite
-        fields = ['id', 'organization', 'email', 'token', 'expires_at', 'status', 'invited_by', 'created_at']
+        fields = [
+            'id', 'organization', 'email', 'role', 'token',
+            'expires_at', 'status', 'invited_by', 'created_at'
+        ]
         read_only_fields = ['token', 'status', 'invited_by', 'created_at', 'organization']
 
 class ProjectMemberSerializer(serializers.ModelSerializer):

--- a/api/src/modules/crm/views.py
+++ b/api/src/modules/crm/views.py
@@ -59,13 +59,31 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     def invite(self, request, pk=None):
         """Пригласить пользователя в организацию"""
         organization = self.get_object()
+        # Проверяем права: только владелец или администратор
+        if not (
+            organization.owner == request.user or
+            OrganizationMember.objects.filter(
+                organization=organization,
+                user=request.user,
+                role__in=['owner', 'admin'],
+                status='accepted'
+            ).exists()
+        ):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
         email = request.data.get('email')
         role = request.data.get('role', organization.default_role)
+
         if not email:
             return Response({'error': 'email is required'}, status=status.HTTP_400_BAD_REQUEST)
+
+        if role not in dict(OrganizationMember.ROLE_CHOICES) or role == 'owner':
+            return Response({'error': 'invalid role'}, status=status.HTTP_400_BAD_REQUEST)
+
         invite = OrganizationInvite.objects.create(
             organization=organization,
             email=email,
+            role=role,
             invited_by=request.user,
         )
         return Response({'token': invite.token, 'status': invite.status}, status=status.HTTP_201_CREATED)
@@ -108,7 +126,7 @@ class OrganizationInviteViewSet(viewsets.ViewSet):
         OrganizationMember.objects.create(
             organization=invite.organization,
             user=request.user,
-            role=invite.organization.default_role,
+            role=invite.role,
             status='accepted',
             invited_by=invite.invited_by,
             invited_at=invite.created_at,

--- a/client/src/config/menu-config.json
+++ b/client/src/config/menu-config.json
@@ -177,6 +177,11 @@
               "name": "Проекты и задачи"
             }
           ]
+        },
+        {
+          "icon": "Building",
+          "routeName": "Organizations",
+          "name": "Организации"
         }
       ]
     },

--- a/client/src/modules/crm/project-management/OrganizationInvites.vue
+++ b/client/src/modules/crm/project-management/OrganizationInvites.vue
@@ -3,7 +3,8 @@
     <h2>Приглашения</h2>
     <ul>
       <li v-for="invite in invites" :key="invite.id">
-        {{ invite.organization }}
+        {{ invite.organization?.name || invite.organization }}
+        <span v-if="invite.role">({{ invite.role }})</span>
         <button @click="accept(invite.token)">Принять</button>
         <button @click="decline(invite.token)">Отклонить</button>
       </li>


### PR DESCRIPTION
## Summary
- allow specifying member role when inviting to an organization
- show organization name and role in invite list
- link organizations page in CRM menu

## Testing
- `PYTHONPATH=/workspace/ergo_ms/api pytest api/src/modules/crm -q`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896b91721b48329852a8dedea4bbf0d