### PR TITLE
feat: improve organization pages layout

### DIFF
--- a/client/src/config/menu-config.json
+++ b/client/src/config/menu-config.json
@@ -185,7 +185,8 @@
           "children": [
             { "routeName": "OrganizationList", "name": "Список организаций" },
             { "routeName": "OrganizationNew", "name": "Создать организацию" },
-            { "routeName": "OrganizationInvites", "name": "Приглашения" }
+            { "routeName": "OrganizationInvites", "name": "Приглашения" },
+            { "routeName": "OrganizationDetails", "name": "Детали организации", "hidden": true }
           ]
         }
       ]

--- a/client/src/config/routes-config.json
+++ b/client/src/config/routes-config.json
@@ -579,6 +579,12 @@
       "component": "@/modules/crm/organizations/OrganizationForm.vue",
       "meta": { "requiresAuth": true, "title": "Создать организацию" }
     },
+    "OrganizationDetails": {
+      "path": "/crm/organizations/:id",
+      "name": "OrganizationDetails",
+      "component": "@/modules/crm/organizations/OrganizationDetails.vue",
+      "meta": { "requiresAuth": true, "title": "Детали организации" }
+    },
     "OrganizationInvites": {
       "path": "/crm/invites",
       "name": "OrganizationInvites",

--- a/client/src/modules/crm/organizations/CRMOrganizationsPage.vue
+++ b/client/src/modules/crm/organizations/CRMOrganizationsPage.vue
@@ -3,6 +3,7 @@
   <div class="page orgs-scope">
     <header class="page__header">
       <h1 class="page__title">CRM · Организации</h1>
+      <p class="muted">Управление организациями и участниками</p>
 
       <div class="page__actions">
         <router-link class="btn btn--primary" :to="{ name: 'OrganizationNew' }">

--- a/client/src/modules/crm/organizations/OrganizationDetails.vue
+++ b/client/src/modules/crm/organizations/OrganizationDetails.vue
@@ -1,0 +1,96 @@
+<template>
+  <section class="card">
+    <header class="card__header">
+      <h2 class="card__title">{{ org.name || 'Организация' }}</h2>
+      <div class="muted" v-if="org.slug">@{{ org.slug }}</div>
+    </header>
+
+    <div class="card__body">
+      <div v-if="loading"><div class="skeleton skeleton--row"></div></div>
+      <div v-else class="org-details">
+        <div class="org-details__info">
+          <p v-if="org.description" class="org-details__description">{{ org.description }}</p>
+          <ul class="org-details__meta">
+            <li v-if="org.website">
+              <label>Сайт</label>
+              <a :href="org.website" target="_blank" rel="noopener">{{ org.website }}</a>
+            </li>
+            <li v-if="org.email">
+              <label>Email</label>
+              <a :href="`mailto:${org.email}`">{{ org.email }}</a>
+            </li>
+            <li v-if="org.phone">
+              <label>Телефон</label>
+              <span>{{ org.phone }}</span>
+            </li>
+            <li v-if="org.address">
+              <label>Адрес</label>
+              <span>{{ org.address }}</span>
+            </li>
+          </ul>
+        </div>
+
+        <div class="org-details__members">
+          <h3>Участники</h3>
+          <div class="table-wrap">
+            <table class="table table--compact">
+              <thead>
+                <tr>
+                  <th>Имя</th>
+                  <th class="hide-sm">Роль</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="m in members" :key="m.id">
+                  <td>{{ m.user?.full_name || m.user }}</td>
+                  <td class="hide-sm">
+                    <span class="badge badge--outline">{{ m.role || 'member' }}</span>
+                  </td>
+                </tr>
+                <tr v-if="members.length === 0">
+                  <td colspan="2"><span class="muted">Нет участников</span></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+import { ref, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+import OrganizationApi from './js/organizationApi.js';
+
+export default {
+  name: 'OrganizationDetails',
+  setup() {
+    const route = useRoute();
+    const org = ref({});
+    const members = ref([]);
+    const loading = ref(false);
+
+    const load = async () => {
+      loading.value = true;
+      try {
+        const id = route.params.id;
+        const [orgResp, membersResp] = await Promise.all([
+          OrganizationApi.getOrganization(id),
+          OrganizationApi.getOrganizationMembers(id)
+        ]);
+        org.value = orgResp?.data || {};
+        members.value = membersResp?.data || [];
+      } finally {
+        loading.value = false;
+      }
+    };
+
+    onMounted(load);
+    return { org, members, loading };
+  }
+};
+</script>
+
+

--- a/client/src/modules/crm/organizations/OrganizationForm.vue
+++ b/client/src/modules/crm/organizations/OrganizationForm.vue
@@ -2,6 +2,7 @@
   <section class="card">
     <header class="card__header">
       <h2 class="card__title">Новая организация</h2>
+      <div class="muted">Заполните форму для создания новой организации</div>
     </header>
 
     <form class="card__body form-grid" @submit.prevent="save">

--- a/client/src/modules/crm/organizations/OrganizationInvites.vue
+++ b/client/src/modules/crm/organizations/OrganizationInvites.vue
@@ -11,7 +11,7 @@
       </div>
 
       <div v-else class="table-wrap">
-        <table class="table table--compact">
+        <table class="table table--hover table--compact">
           <thead>
             <tr>
               <th>Организация</th>

--- a/client/src/modules/crm/organizations/OrganizationsList.vue
+++ b/client/src/modules/crm/organizations/OrganizationsList.vue
@@ -2,6 +2,7 @@
   <section class="card">
     <header class="card__header">
       <h2 class="card__title">Организации</h2>
+      <div class="muted">Список доступных вам организаций</div>
 
       <div class="toolbar">
         <div class="toolbar__left">

--- a/client/src/modules/crm/organizations/js/organizationApi.js
+++ b/client/src/modules/crm/organizations/js/organizationApi.js
@@ -34,6 +34,13 @@ class OrganizationApi {
     }
 
     /**
+     * Получить информацию об одной организации
+     */
+    async getOrganization(id) {
+        return await this.client.get(`/crm/organizations/${id}/`);
+    }
+
+    /**
      * Создать новую организацию
      * @param {Object} data { name, ... }
      */

--- a/client/src/modules/crm/organizations/orgs.scss
+++ b/client/src/modules/crm/organizations/orgs.scss
@@ -26,8 +26,18 @@
 
     .inline-edit { display: inline-flex; align-items: center; gap: 8px; }
 
+    /* блок информации о конкретной организации */
+    .org-details { display: flex; flex-direction: column; gap: 24px; }
+    .org-details__meta { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: 16px; }
+    .org-details__meta li { min-width: 180px; }
+    .org-details__meta label { display: block; font-size: .75rem; opacity: .7; }
+    .org-details__members h3 { font-size: 1rem; margin-bottom: 8px; }
+
     /* бейджи: оставляем размеры; цвета возьмутся из темы (если есть), иначе дефолт темы */
     .badge { font-size: .75rem; line-height: 1.2; }
+
+    /* небольшое расстояние между заголовком карточки и описанием */
+    .card__header .muted { margin-top: 4px; }
 
     /* адаптив */
     @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- polish layout across CRM organization pages
- add detailed organization view with member list
- expose API call and route for organization details

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/modules/crm/organizations --ext .js,.vue`

------
https://chatgpt.com/codex/tasks/task_e_6896d5f59ee08329ac6e4969ccb6e363