### PR TITLE
Add organization member management and deletion features

### DIFF
--- a/api/src/modules/crm/views.py
+++ b/api/src/modules/crm/views.py
@@ -55,6 +55,12 @@ class OrganizationViewSet(viewsets.ModelViewSet):
             responded_at=timezone.now()
         )
 
+    def destroy(self, request, *args, **kwargs):
+        organization = self.get_object()
+        if organization.owner != request.user:
+            return Response(status=status.HTTP_403_FORBIDDEN)
+        return super().destroy(request, *args, **kwargs)
+
     @action(detail=True, methods=['post'])
     def invite(self, request, pk=None):
         """Пригласить пользователя в организацию"""
@@ -96,6 +102,30 @@ class OrganizationViewSet(viewsets.ModelViewSet):
             return Response(status=status.HTTP_403_FORBIDDEN)
         serializer = OrganizationMemberSerializer(organization.memberships.all(), many=True)
         return Response(serializer.data)
+
+    @action(detail=True, methods=['patch', 'delete'], url_path='members/(?P<user_id>[^/.]+)')
+    def manage_member(self, request, pk=None, user_id=None):
+        """Изменение роли или удаление участника"""
+        organization = self.get_object()
+        if not (organization.owner == request.user or OrganizationMember.objects.filter(organization=organization, user=request.user, role__in=['owner', 'admin'], status='accepted').exists()):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+        try:
+            member = OrganizationMember.objects.get(organization=organization, user_id=user_id)
+        except OrganizationMember.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        if request.method == 'PATCH':
+            role = request.data.get('role')
+            if role not in dict(OrganizationMember.ROLE_CHOICES) or role == 'owner':
+                return Response({'error': 'invalid role'}, status=status.HTTP_400_BAD_REQUEST)
+            member.role = role
+            member.save()
+            return Response(OrganizationMemberSerializer(member).data)
+
+        if member.role == 'owner':
+            return Response({'error': 'cannot remove owner'}, status=status.HTTP_400_BAD_REQUEST)
+        member.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class OrganizationInviteViewSet(viewsets.ViewSet):

--- a/client/src/modules/crm/organizations/OrganizationDetails.vue
+++ b/client/src/modules/crm/organizations/OrganizationDetails.vue
@@ -4,6 +4,9 @@
     <section class="card">
       <header class="card__header">
         <h2 class="card__title">Общая информация</h2>
+        <div class="toolbar" v-if="canDelete">
+          <button class="btn btn--sm btn--danger" @click="deleteOrg">Удалить</button>
+        </div>
       </header>
 
       <div class="card__body">
@@ -111,7 +114,18 @@
                     </div>
                   </div>
                 </td>
-                <td><span class="badge badge--outline">{{ m.role }}</span></td>
+                <td>
+                  <template v-if="canManage && m.role !== 'owner'">
+                    <select v-model="m.role" class="select select--xs" @change="changeRole(m.user.id, m.role)">
+                      <option value="admin">admin</option>
+                      <option value="member">member</option>
+                      <option value="viewer">viewer</option>
+                    </select>
+                  </template>
+                  <template v-else>
+                    <span class="badge badge--outline">{{ m.role }}</span>
+                  </template>
+                </td>
                 <td>
                   <span class="badge" :class="m.status === 'accepted' ? 'badge--success' : 'badge--muted'">
                     {{ m.status }}
@@ -174,7 +188,7 @@
 <script>
 import { ref, computed, onMounted } from 'vue';
 import { useStore } from 'vuex';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import OrganizationApi from './js/organizationApi.js';
 import OrganizationInviteModal from './components/OrganizationInviteModal.vue';
 
@@ -184,6 +198,7 @@ export default {
   setup() {
     const store = useStore();
     const route = useRoute();
+    const router = useRouter();
     const userId = store.state?.auth?.user?.id;
     const id = Number(route.params.id);
 
@@ -258,6 +273,7 @@ export default {
       isOwner.value || members.value.some(m => m.user?.id === userId && (m.role === 'admin' || m.role === 'owner'))
     );
     const canManage = canInvite;
+    const canDelete = isOwner;
 
     // helpers
     const initials = (u) => (u?.full_name || u?.username || u?.email || 'U').slice(0,1).toUpperCase();
@@ -267,6 +283,17 @@ export default {
       if (!confirm('Удалить участника из организации?')) return;
       await OrganizationApi.removeOrganizationMember(id, userIdToRemove);
       await loadMembers();
+    };
+
+    const changeRole = async (userIdToChange, role) => {
+      await OrganizationApi.updateOrganizationMember(id, userIdToChange, { role });
+      await loadMembers();
+    };
+
+    const deleteOrg = async () => {
+      if (!confirm('Удалить организацию?')) return;
+      await OrganizationApi.deleteOrganization(id);
+      router.push({ name: 'OrganizationList' });
     };
 
     const onInviteSubmit = async ({ email, role }) => {
@@ -288,7 +315,7 @@ export default {
       org, members, projects,
       loadingOrg, loadingMembers, loadingProjects,
       showInvite, inviting, onInviteSubmit,
-      myRole, canInvite, canManage, initials, removeMember,
+      myRole, canInvite, canManage, canDelete, initials, removeMember, changeRole, deleteOrg,
       normalizedWebsite, displayWebsite, telHref, membersCount
     };
   }

--- a/client/src/modules/crm/organizations/js/organizationApi.js
+++ b/client/src/modules/crm/organizations/js/organizationApi.js
@@ -25,8 +25,9 @@ class OrganizationApi {
   archiveOrganization(id) { return this.client.post(`/crm/organizations/${id}/archive`); }
 
   // Участники
-  getOrganizationMembers(id) { return this.client.get(`/crm/organizations/${id}/members`); }
-  removeOrganizationMember(orgId, userId) { return this.client.delete(`/crm/organizations/${orgId}/members/${userId}`); }
+  getOrganizationMembers(id) { return this.client.get(`/crm/organizations/${id}/members/`); }
+  updateOrganizationMember(orgId, userId, data) { return this.client.patch(`/crm/organizations/${orgId}/members/${userId}/`, data); }
+  removeOrganizationMember(orgId, userId) { return this.client.delete(`/crm/organizations/${orgId}/members/${userId}/`); }
 
   // Инвайты (внутри организации)
   inviteToOrganization(orgId, data) { return this.client.post(`/crm/organizations/${orgId}/invite/`, data); }
@@ -38,6 +39,8 @@ class OrganizationApi {
 
   // Проекты (по организации)
   getProjects(orgId) { return this.client.get('/crm/projects/', { params: { organization_id: orgId } }); }
+
+  deleteOrganization(id) { return this.client.delete(`/crm/organizations/${id}/`); }
 }
 
 export default new OrganizationApi();


### PR DESCRIPTION
## Summary
- allow owners to delete organizations and restrict deletion to them
- enable owners/admins to change member roles or remove members
- expose organization deletion and member management in client UI and API wrapper

## Testing
- `pytest`
- `npm run lint` *(fails: 370 problems (370 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6897a4fe86808329a43f3f4a65fa3ed6