### PR TITLE
feat: refine organization roles and editing

### DIFF
--- a/api/src/modules/crm/migrations/0011_update_organization_fields.py
+++ b/api/src/modules/crm/migrations/0011_update_organization_fields.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+def migrate_visibility(apps, schema_editor):
+    Organization = apps.get_model('crm', 'Organization')
+    Organization.objects.filter(visibility='by_invite').update(visibility='internal')
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('crm', '0010_ensure_owner_membership'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='organization',
+            name='logo_url',
+            field=models.URLField(default='', blank=True, verbose_name='Логотип'),
+        ),
+        migrations.AlterField(
+            model_name='organization',
+            name='visibility',
+            field=models.CharField(max_length=20, choices=[('public', 'public'), ('internal', 'internal'), ('private', 'private')], default='private', verbose_name='Видимость'),
+        ),
+        migrations.AlterField(
+            model_name='organization',
+            name='default_role',
+            field=models.CharField(max_length=20, choices=[('member', 'member'), ('admin', 'admin'), ('viewer', 'viewer')], default='member', verbose_name='Роль по умолчанию'),
+        ),
+        migrations.RunPython(migrate_visibility, reverse_code=migrations.RunPython.noop),
+    ]

--- a/api/src/modules/crm/models.py
+++ b/api/src/modules/crm/models.py
@@ -102,11 +102,13 @@ class TaskPriority(models.Model):
 class Organization(models.Model):
     """Организация в CRM"""
     VISIBILITY_CHOICES = [
+        ('public', 'public'),
+        ('internal', 'internal'),
         ('private', 'private'),
-        ('by_invite', 'by_invite'),
     ]
     ROLE_CHOICES = [
         ('member', 'member'),
+        ('admin', 'admin'),
         ('viewer', 'viewer'),
     ]
     STATUS_CHOICES = [
@@ -117,7 +119,7 @@ class Organization(models.Model):
     name = models.CharField(max_length=255, verbose_name='Название организации')
     slug = models.SlugField(unique=True, blank=True, verbose_name='Слаг')
     description = models.TextField(blank=True, verbose_name='Описание')
-    logo_url = models.URLField(blank=True, verbose_name='Логотип')
+    logo_url = models.URLField(default='', blank=True, verbose_name='Логотип')
     industry = models.CharField(max_length=255, blank=True, verbose_name='Отрасль')
     website = models.URLField(blank=True, verbose_name='Сайт')
     email = models.EmailField(blank=True, verbose_name='Email')
@@ -130,7 +132,7 @@ class Organization(models.Model):
     billing_address = models.CharField(max_length=255, blank=True, verbose_name='Адрес для счетов')
     owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name='owned_organizations', verbose_name='Владелец')
     members = models.ManyToManyField(User, through='OrganizationMember', related_name='organizations', through_fields=('organization', 'user'), verbose_name='Участники')
-    visibility = models.CharField(max_length=20, choices=VISIBILITY_CHOICES, default='by_invite', verbose_name='Видимость')
+    visibility = models.CharField(max_length=20, choices=VISIBILITY_CHOICES, default='private', verbose_name='Видимость')
     default_role = models.CharField(max_length=20, choices=ROLE_CHOICES, default='member', verbose_name='Роль по умолчанию')
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='active', verbose_name='Статус')
     created_at = models.DateTimeField(auto_now_add=True, verbose_name='Дата создания')

--- a/api/src/modules/crm/views.py
+++ b/api/src/modules/crm/views.py
@@ -39,11 +39,11 @@ class OrganizationViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        # Публичные или те, где пользователь владелец/админ
+        # Публичные или те, где пользователь владелец/админ (статус accepted)
         return Organization.objects.filter(
             Q(visibility='public') |
             Q(owner=user) |
-            Q(memberships__user=user, memberships__role__in=['owner', 'admin', 'member', 'viewer'], memberships__status='accepted')
+            Q(memberships__user=user, memberships__role__in=['owner', 'admin'], memberships__status='accepted')
         ).distinct()
 
     def perform_create(self, serializer):
@@ -116,7 +116,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     def members(self, request, pk=None):
         """Список участников организации"""
         organization = self.get_object()
-        if not (organization.owner == request.user or OrganizationMember.objects.filter(organization=organization, user=request.user, role__in=['owner', 'admin'], status='accepted').exists()):
+        if not self._is_owner_or_admin(organization, request.user):
             return Response(status=status.HTTP_403_FORBIDDEN)
         serializer = OrganizationMemberSerializer(organization.memberships.all(), many=True)
         return Response(serializer.data)
@@ -125,7 +125,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     def manage_member(self, request, pk=None, user_id=None):
         """Изменение роли или удаление участника"""
         organization = self.get_object()
-        if not (organization.owner == request.user or OrganizationMember.objects.filter(organization=organization, user=request.user, role__in=['owner', 'admin'], status='accepted').exists()):
+        if not self._is_owner_or_admin(organization, request.user):
             return Response(status=status.HTTP_403_FORBIDDEN)
         try:
             member = OrganizationMember.objects.get(organization=organization, user_id=user_id)

--- a/client/src/modules/crm/organizations/OrganizationDetails.vue
+++ b/client/src/modules/crm/organizations/OrganizationDetails.vue
@@ -6,7 +6,7 @@
         <h2 class="card__title">Общая информация</h2>
 
         <div class="toolbar">
-          <button v-if="isOwner" class="btn btn--sm btn--danger btn--ghost" @click="onDelete">
+          <button v-if="canManage" class="btn btn--sm btn--danger btn--ghost" @click="onDelete">
             Удалить организацию
           </button>
 
@@ -159,6 +159,14 @@
                 <option value="member">member</option>
                 <option value="admin">admin</option>
                 <option value="viewer">viewer</option>
+              </select>
+            </label>
+
+            <label>
+              <span>Статус</span>
+              <select v-model="editForm.status" class="input">
+                <option value="active">active</option>
+                <option value="archived">archived</option>
               </select>
             </label>
           </div>
@@ -339,8 +347,12 @@ export default {
 
     const removeMember = async (userIdToRemove) => {
       if (!confirm('Удалить участника из организации?')) return;
-      await OrganizationApi.removeOrganizationMember(id, userIdToRemove);
-      await loadMembers();
+      try {
+        await OrganizationApi.removeOrganizationMember(id, userIdToRemove);
+        await loadMembers();
+      } catch (e) {
+        alert(e?.response?.data?.detail || 'Ошибка удаления участника');
+      }
     };
 
     const onInviteSubmit = async ({ email, role }) => {
@@ -349,6 +361,8 @@ export default {
         await OrganizationApi.inviteToOrganization(id, { email, role });
         showInvite.value = false;
         await loadMembers();
+      } catch (e) {
+        alert(e?.response?.data?.detail || 'Ошибка приглашения');
       } finally {
         inviting.value = false;
       }
@@ -356,8 +370,12 @@ export default {
 
     const onDelete = async () => {
       if (!confirm('Удалить организацию? Это действие нельзя отменить.')) return;
-      await OrganizationApi.deleteOrganization(id);
-      router.push({ name: 'OrganizationList' });
+      try {
+        await OrganizationApi.deleteOrganization(id);
+        router.push({ name: 'OrganizationList' });
+      } catch (e) {
+        alert(e?.response?.data?.detail || 'Ошибка удаления');
+      }
     };
 
     // === редактирование: старт/отмена/сохранение ===
@@ -365,7 +383,8 @@ export default {
       editForm.value = {
         visibility: 'private',
         default_role: 'member',
-        ...org.value
+        status: 'active',
+        ...org.value,
       };
       editMode.value = true;
     };
@@ -374,8 +393,15 @@ export default {
       editMode.value = false;
     };
     const sanitizePatch = (data) => {
-      const patch = { ...data };
-      Object.keys(patch).forEach(k => { if (patch[k] === '') patch[k] = null; });
+      const allowed = ['name','website','email','phone','country','timezone','address','description','industry','billing_name','billing_vat','billing_address','visibility','default_role','status'];
+      const patch = {};
+      allowed.forEach(k => {
+        const val = data[k];
+        if (val !== undefined && val !== null && val !== '' && val !== org.value[k]) {
+          patch[k] = val;
+        }
+      });
+      if (patch.default_role === 'owner') patch.default_role = 'member';
       return patch;
     };
     const saveInfo = async () => {
@@ -384,6 +410,8 @@ export default {
         await OrganizationApi.updateOrganization(id, sanitizePatch(editForm.value));
         editMode.value = false;
         await loadOrg();
+      } catch (e) {
+        alert(e?.response?.data?.detail || 'Ошибка сохранения');
       } finally {
         saving.value = false;
       }


### PR DESCRIPTION
## Summary
- broaden Organization visibility and roles, ensure logo has default
- restrict Organization access to owner/admin and expose members management
- improve org details view: admin controls, status editing, safe PATCH requests

## Testing
- `PYTHONPATH=. python src/manage.py test`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898017346e4832998e650cb558a6db5