### PR TITLE
Allow members to view organizations and manage member statuses

### DIFF
--- a/api/src/modules/crm/views.py
+++ b/api/src/modules/crm/views.py
@@ -39,11 +39,11 @@ class OrganizationViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        # Публичные или те, где пользователь владелец/админ (статус accepted)
+        # Публичные или те, где пользователь владелец/участник (статус accepted)
         return Organization.objects.filter(
             Q(visibility='public') |
             Q(owner=user) |
-            Q(memberships__user=user, memberships__role__in=['owner', 'admin'], memberships__status='accepted')
+            Q(memberships__user=user, memberships__status='accepted')
         ).distinct()
 
     def perform_create(self, serializer):
@@ -134,10 +134,25 @@ class OrganizationViewSet(viewsets.ModelViewSet):
 
         if request.method == 'PATCH':
             role = request.data.get('role')
-            if role not in dict(OrganizationMember.ROLE_CHOICES) or role == 'owner':
-                return Response({'error': 'invalid role'}, status=status.HTTP_400_BAD_REQUEST)
-            member.role = role
-            member.save()
+            status_val = request.data.get('status')
+            updated = False
+
+            if role is not None:
+                if role not in dict(OrganizationMember.ROLE_CHOICES) or role == 'owner':
+                    return Response({'error': 'invalid role'}, status=status.HTTP_400_BAD_REQUEST)
+                member.role = role
+                updated = True
+
+            if status_val is not None:
+                if status_val not in dict(OrganizationMember.STATUS_CHOICES):
+                    return Response({'error': 'invalid status'}, status=status.HTTP_400_BAD_REQUEST)
+                member.status = status_val
+                member.responded_at = timezone.now()
+                updated = True
+
+            if updated:
+                member.save()
+
             return Response(OrganizationMemberSerializer(member).data)
 
         if member.role == 'owner':

--- a/client/src/modules/crm/organizations/OrganizationDetails.vue
+++ b/client/src/modules/crm/organizations/OrganizationDetails.vue
@@ -209,7 +209,12 @@
                 </td>
                 <td><span class="badge badge--outline">{{ m.role || 'member' }}</span></td>
                 <td>
-                  <span class="badge" :class="(m.status || 'pending') === 'accepted' ? 'badge--success' : 'badge--muted'">
+                  <template v-if="canManage">
+                    <select v-model="m.status" class="input input--sm" @change="changeStatus(m)">
+                      <option v-for="s in memberStatuses" :key="s" :value="s">{{ s }}</option>
+                    </select>
+                  </template>
+                  <span v-else class="badge" :class="(m.status || 'pending') === 'accepted' ? 'badge--success' : 'badge--muted'">
                     {{ m.status || 'pending' }}
                   </span>
                 </td>
@@ -343,7 +348,18 @@ export default {
       (o?.my_role) ||
       (toStr(o?.owner?.id ?? o?.owner_id) === uid.value ? 'owner' : 'member');
 
+    const memberStatuses = ['pending', 'accepted', 'declined', 'revoked'];
+
     const initials = (u) => (u?.full_name || u?.username || u?.email || 'U').slice(0,1).toUpperCase();
+
+    const changeStatus = async (m) => {
+      try {
+        await OrganizationApi.updateOrganizationMember(id, m.user.id, { status: m.status });
+        await loadMembers();
+      } catch (e) {
+        alert(e?.response?.data?.detail || 'Ошибка изменения статуса');
+      }
+    };
 
     const removeMember = async (userIdToRemove) => {
       if (!confirm('Удалить участника из организации?')) return;
@@ -436,7 +452,7 @@ export default {
       myRole, canInvite, canManage, isOwner,
 
       // members
-      initials, removeMember,
+      initials, removeMember, changeStatus, memberStatuses,
 
       // удаление
       onDelete,

--- a/client/src/modules/crm/organizations/OrganizationsList.vue
+++ b/client/src/modules/crm/organizations/OrganizationsList.vue
@@ -171,7 +171,7 @@ export default {
       await load();
     }
 
-    const myRole = (org) => (isOwner(org) ? 'owner' : (org.my_role || 'member'));
+    const myRole = (org) => (isOwner(org) ? 'owner' : (org.my_role || '-'));
 
     const startEdit = (org) => { editingId.value = org.id; editName.value = org.name || ''; };
     const cancelEdit = () => { editingId.value = null; editName.value = ''; };


### PR DESCRIPTION
## Summary
- include all accepted members in organization listing and mark public organizations with no membership
- enable admins and owners to edit organization member status directly

## Testing
- `npm run lint` (fails: Unknown env config "http-proxy" and 372 other errors)
- `poetry run python src/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689807c96b54832992cc2ddbe3c7025a