### PR TITLE
Allow members to view organizations and manage roles, require ownership transfer on deletion

### DIFF
--- a/api/src/modules/crm/views.py
+++ b/api/src/modules/crm/views.py
@@ -39,11 +39,11 @@ class OrganizationViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        # Публичные или те, где пользователь владелец/админ (статус accepted)
+        # Публичные или те, где пользователь владелец/участник (статус accepted)
         return Organization.objects.filter(
             Q(visibility='public') |
             Q(owner=user) |
-            Q(memberships__user=user, memberships__role__in=['owner', 'admin'], memberships__status='accepted')
+            Q(memberships__user=user, memberships__status='accepted')
         ).distinct()
 
     def perform_create(self, serializer):
@@ -74,8 +74,32 @@ class OrganizationViewSet(viewsets.ModelViewSet):
 
     def destroy(self, request, *args, **kwargs):
         org = self.get_object()
-        if not self._is_owner_or_admin(org, request.user):
+        # только владелец может удалять организацию
+        if org.owner_id != request.user.id:
             return Response({'detail': 'Недостаточно прав'}, status=status.HTTP_403_FORBIDDEN)
+
+        new_owner_id = request.data.get('new_owner_id')
+        if not new_owner_id:
+            return Response({'detail': 'Необходимо указать new_owner_id'}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            new_owner = User.objects.get(id=new_owner_id)
+        except User.DoesNotExist:
+            return Response({'detail': 'Пользователь не найден'}, status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            OrganizationMember.objects.get(organization=org, user=new_owner, status='accepted')
+        except OrganizationMember.DoesNotExist:
+            return Response({'detail': 'Пользователь должен быть участником организации со статусом accepted.'},
+                            status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            OrganizationMember.objects.update_or_create(
+                organization=org, user=new_owner,
+                defaults={'role': 'owner', 'status': 'accepted'}
+            )
+            OrganizationMember.objects.filter(organization=org, user=request.user).delete()
+
         return super().destroy(request, *args, **kwargs)
 
     @action(detail=True, methods=['post'])

--- a/client/src/modules/crm/organizations/OrganizationDetails.vue
+++ b/client/src/modules/crm/organizations/OrganizationDetails.vue
@@ -207,7 +207,14 @@
                     </div>
                   </div>
                 </td>
-                <td><span class="badge badge--outline">{{ m.role || 'member' }}</span></td>
+                <td>
+                  <template v-if="canManage">
+                    <select v-model="m.role" class="input input--sm" @change="changeRole(m)" :disabled="m.role === 'owner'">
+                      <option v-for="r in memberRoles" :key="r" :value="r">{{ r }}</option>
+                    </select>
+                  </template>
+                  <span v-else class="badge badge--outline">{{ m.role || 'member' }}</span>
+                </td>
                 <td>
                   <span class="badge" :class="(m.status || 'pending') === 'accepted' ? 'badge--success' : 'badge--muted'">
                     {{ m.status || 'pending' }}
@@ -343,7 +350,18 @@ export default {
       (o?.my_role) ||
       (toStr(o?.owner?.id ?? o?.owner_id) === uid.value ? 'owner' : 'member');
 
+    const memberRoles = ['admin', 'member', 'viewer'];
+
     const initials = (u) => (u?.full_name || u?.username || u?.email || 'U').slice(0,1).toUpperCase();
+
+    const changeRole = async (m) => {
+      try {
+        await OrganizationApi.updateOrganizationMember(id, m.user.id, { role: m.role });
+        await loadMembers();
+      } catch (e) {
+        alert(e?.response?.data?.detail || 'Ошибка изменения роли');
+      }
+    };
 
     const removeMember = async (userIdToRemove) => {
       if (!confirm('Удалить участника из организации?')) return;
@@ -369,9 +387,11 @@ export default {
     };
 
     const onDelete = async () => {
+      const newOwnerId = prompt('ID нового владельца');
+      if (!newOwnerId) return;
       if (!confirm('Удалить организацию? Это действие нельзя отменить.')) return;
       try {
-        await OrganizationApi.deleteOrganization(id);
+        await OrganizationApi.deleteOrganization(id, newOwnerId);
         router.push({ name: 'OrganizationList' });
       } catch (e) {
         alert(e?.response?.data?.detail || 'Ошибка удаления');
@@ -436,7 +456,7 @@ export default {
       myRole, canInvite, canManage, isOwner,
 
       // members
-      initials, removeMember,
+      initials, removeMember, changeRole, memberRoles,
 
       // удаление
       onDelete,

--- a/client/src/modules/crm/organizations/OrganizationsList.vue
+++ b/client/src/modules/crm/organizations/OrganizationsList.vue
@@ -171,7 +171,7 @@ export default {
       await load();
     }
 
-    const myRole = (org) => (isOwner(org) ? 'owner' : (org.my_role || 'member'));
+    const myRole = (org) => (isOwner(org) ? 'owner' : (org.my_role || '-'));
 
     const startEdit = (org) => { editingId.value = org.id; editName.value = org.name || ''; };
     const cancelEdit = () => { editingId.value = null; editName.value = ''; };

--- a/client/src/modules/crm/organizations/js/organizationApi.js
+++ b/client/src/modules/crm/organizations/js/organizationApi.js
@@ -25,9 +25,9 @@ class OrganizationApi {
   async updateOrganization(id, data) { return await this.client.patch(`/crm/organizations/${id}/`, data); }
 // убедитесь, что этот метод есть (и baseURL = '/api'):
   // create/update/delete
-    async deleteOrganization(id) {
+    async deleteOrganization(id, newOwnerId) {
         // DRF обычно возвращает 204 No Content
-        const resp = await this.client.delete(`/crm/organizations/${id}/`);
+        const resp = await this.client.delete(`/crm/organizations/${id}/`, { data: { new_owner_id: newOwnerId } });
         return resp?.status ?? 204;
     }
 


### PR DESCRIPTION
## Summary
- restrict organization deletion to owners and require specifying a new owner
- allow admins and owners to change an organization member's role
- expose role editing in the member list and pass new owner id on delete

## Testing
- `npm run lint` (fails: 'process' is not defined and other errors)
- `poetry run python src/manage.py test` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_689807c96b54832992cc2ddbe3c7025a