### PR TITLE
Allow members to leave organizations and simplify owner management

### DIFF
--- a/api/src/modules/crm/views.py
+++ b/api/src/modules/crm/views.py
@@ -74,32 +74,9 @@ class OrganizationViewSet(viewsets.ModelViewSet):
 
     def destroy(self, request, *args, **kwargs):
         org = self.get_object()
-        # только владелец может удалять организацию
+        # удалить организацию может только владелец
         if org.owner_id != request.user.id:
             return Response({'detail': 'Недостаточно прав'}, status=status.HTTP_403_FORBIDDEN)
-
-        new_owner_id = request.data.get('new_owner_id')
-        if not new_owner_id:
-            return Response({'detail': 'Необходимо указать new_owner_id'}, status=status.HTTP_400_BAD_REQUEST)
-
-        try:
-            new_owner = User.objects.get(id=new_owner_id)
-        except User.DoesNotExist:
-            return Response({'detail': 'Пользователь не найден'}, status=status.HTTP_404_NOT_FOUND)
-
-        try:
-            OrganizationMember.objects.get(organization=org, user=new_owner, status='accepted')
-        except OrganizationMember.DoesNotExist:
-            return Response({'detail': 'Пользователь должен быть участником организации со статусом accepted.'},
-                            status=status.HTTP_400_BAD_REQUEST)
-
-        with transaction.atomic():
-            OrganizationMember.objects.update_or_create(
-                organization=org, user=new_owner,
-                defaults={'role': 'owner', 'status': 'accepted'}
-            )
-            OrganizationMember.objects.filter(organization=org, user=request.user).delete()
-
         return super().destroy(request, *args, **kwargs)
 
     @action(detail=True, methods=['post'])
@@ -157,13 +134,28 @@ class OrganizationViewSet(viewsets.ModelViewSet):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         if request.method == 'PATCH':
+            if str(member.user_id) == str(request.user.id):
+                return Response({'error': 'cannot change own role'}, status=status.HTTP_400_BAD_REQUEST)
             role = request.data.get('role')
             status_val = request.data.get('status')
             updated = False
 
             if role is not None:
-                if role not in dict(OrganizationMember.ROLE_CHOICES) or role == 'owner':
+                if role not in dict(OrganizationMember.ROLE_CHOICES):
                     return Response({'error': 'invalid role'}, status=status.HTTP_400_BAD_REQUEST)
+                if role == 'owner':
+                    if organization.owner_id != request.user.id:
+                        return Response({'error': 'invalid role'}, status=status.HTTP_400_BAD_REQUEST)
+                    with transaction.atomic():
+                        organization.owner = member.user
+                        organization.save(update_fields=['owner'])
+                        OrganizationMember.objects.filter(
+                            organization=organization,
+                            user=request.user
+                        ).update(role='admin')
+                        member.role = 'owner'
+                        member.save(update_fields=['role'])
+                    return Response(OrganizationMemberSerializer(member).data)
                 member.role = role
                 updated = True
 

--- a/client/src/modules/crm/organizations/OrganizationDetails.vue
+++ b/client/src/modules/crm/organizations/OrganizationDetails.vue
@@ -9,6 +9,9 @@
           <button v-if="canManage" class="btn btn--sm btn--danger btn--ghost" @click="onDelete">
             Удалить организацию
           </button>
+          <button v-if="isParticipant" class="btn btn--sm btn--ghost" @click="onLeave">
+            Выйти из организации
+          </button>
 
           <!-- Редактирование общей информации -->
           <button
@@ -208,20 +211,15 @@
                   </div>
                 </td>
                 <td>
-                  <template v-if="canManage">
-                    <select v-model="m.role" class="input input--sm" @change="changeRole(m)" :disabled="m.role === 'owner'">
+                  <template v-if="canChangeRole(m)">
+                    <select v-model="m.role" class="input input--sm" @change="changeRole(m)">
                       <option v-for="r in memberRoles" :key="r" :value="r">{{ r }}</option>
                     </select>
                   </template>
                   <span v-else class="badge badge--outline">{{ m.role || 'member' }}</span>
                 </td>
                 <td>
-                  <template v-if="canManage">
-                    <select v-model="m.status" class="input input--sm" @change="changeStatus(m)">
-                      <option v-for="s in memberStatuses" :key="s" :value="s">{{ s }}</option>
-                    </select>
-                  </template>
-                  <span v-else class="badge" :class="(m.status || 'pending') === 'accepted' ? 'badge--success' : 'badge--muted'">
+                  <span class="badge" :class="(m.status || 'pending') === 'accepted' ? 'badge--success' : 'badge--muted'">
                     {{ m.status || 'pending' }}
                   </span>
                 </td>
@@ -297,6 +295,8 @@ export default {
 
     const org = ref({});
     const members = ref([]);
+    const myMember = ref(null);
+    const isParticipant = ref(false);
     const projects = ref([]);
 
     const loadingOrg = ref(false);
@@ -324,6 +324,7 @@ export default {
       try {
         const resp = await OrganizationApi.getOrganizationMembers(id);
         members.value = resp?.data || [];
+        updateMyMember();
       } finally { loadingMembers.value = false; }
     };
 
@@ -344,25 +345,35 @@ export default {
       org.value?.my_role === 'owner' || (uid.value && ownerIdFromOrg.value === uid.value)
     );
 
-    const myMember = computed(() => members.value.find(m => toStr(m.user?.id) === uid.value));
     const isAdminFromMembers = computed(() => ['admin', 'owner'].includes(myMember.value?.role));
     const isAdmin = computed(() => org.value?.my_role === 'admin' || isAdminFromMembers.value);
 
     const canInvite = computed(() => isOwner.value || isAdmin.value);
     const canManage = canInvite;
 
+    function updateMyMember() {
+      myMember.value = members.value.find(m => toStr(m.user?.id) === uid.value) || null;
+      isParticipant.value = !!myMember.value;
+    }
+    watch([members, uid], updateMyMember, { immediate: true });
+
     const myRole = (o) =>
       (o?.my_role) ||
       (toStr(o?.owner?.id ?? o?.owner_id) === uid.value ? 'owner' : 'member');
       
-    const memberRoles = ['admin', 'member', 'viewer'];
+    const memberRoles = computed(() =>
+      isOwner.value ? ['owner', 'admin', 'member', 'viewer'] : ['admin', 'member', 'viewer']
+    );
+
+    const canChangeRole = (m) =>
+      (isOwner.value || isAdmin.value) && toStr(m.user?.id) !== uid.value && m.role !== 'owner';
 
     const initials = (u) => (u?.full_name || u?.username || u?.email || 'U').slice(0,1).toUpperCase();
 
     const changeRole = async (m) => {
       try {
         await OrganizationApi.updateOrganizationMember(id, m.user.id, { role: m.role });
-        await loadMembers();
+        await Promise.all([loadMembers(), loadOrg()]);
       } catch (e) {
         alert(e?.response?.data?.detail || 'Ошибка изменения роли');
       }
@@ -392,14 +403,26 @@ export default {
     };
 
     const onDelete = async () => {
-      const newOwnerId = prompt('ID нового владельца');
-      if (!newOwnerId) return;
       if (!confirm('Удалить организацию? Это действие нельзя отменить.')) return;
       try {
-        await OrganizationApi.deleteOrganization(id, newOwnerId);
+        await OrganizationApi.deleteOrganization(id);
         router.push({ name: 'OrganizationList' });
       } catch (e) {
         alert(e?.response?.data?.detail || 'Ошибка удаления');
+      }
+    };
+
+    const onLeave = async () => {
+      if (isOwner.value) {
+        alert('Вы владелец организации. Сначала передайте статус владельца.');
+        return;
+      }
+      if (!confirm('Выйти из организации?')) return;
+      try {
+        await OrganizationApi.leaveOrganization(id);
+        router.push({ name: 'OrganizationList' });
+      } catch (e) {
+        alert(e?.response?.data?.detail || 'Ошибка выхода');
       }
     };
 
@@ -458,13 +481,13 @@ export default {
       showInvite, inviting, onInviteSubmit,
 
       // права
-      myRole, canInvite, canManage, isOwner,
+      myRole, canInvite, canManage, isOwner, isParticipant,
 
       // members
-      initials, removeMember, changeRole, memberRoles,
+      initials, removeMember, changeRole, memberRoles, canChangeRole,
 
-      // удаление
-      onDelete,
+      // действия
+      onDelete, onLeave,
 
       // edit
       editMode, startEdit, cancelEdit, saveInfo, saving, editForm

--- a/client/src/modules/crm/organizations/js/organizationApi.js
+++ b/client/src/modules/crm/organizations/js/organizationApi.js
@@ -25,11 +25,10 @@ class OrganizationApi {
   async updateOrganization(id, data) { return await this.client.patch(`/crm/organizations/${id}/`, data); }
 // убедитесь, что этот метод есть (и baseURL = '/api'):
   // create/update/delete
-    async deleteOrganization(id, newOwnerId) {
-        // DRF обычно возвращает 204 No Content
-        const resp = await this.client.delete(`/crm/organizations/${id}/`, { data: { new_owner_id: newOwnerId } });
-        return resp?.status ?? 204;
-    }
+  async deleteOrganization(id) {
+    const resp = await this.client.delete(`/crm/organizations/${id}/`);
+    return resp?.status ?? 204;
+  }
 
 
   async archiveOrganization(id) { return await this.client.post(`/crm/organizations/${id}/archive`); }
@@ -41,6 +40,9 @@ class OrganizationApi {
     // если на бэке есть отдельная ручка — подставить; иначе временный эндпоинт недоступен
     // здесь показываем пример DELETE на гипотетический /members/{user_id}
     return await this.client.delete(`/crm/organizations/${id}/members/${userId}/`);
+  }
+  async leaveOrganization(id) {
+    return await this.client.post(`/crm/organizations/${id}/leave/`);
   }
   async getProjects(orgId) { return await this.client.get(`/crm/projects/`, { params: { organization: orgId } }); }
 


### PR DESCRIPTION
## Summary
- Prevent users from changing their own role in an organization while allowing owners to transfer ownership
- Show role dropdowns only when current user may edit another member's role and ensure leave button appears once membership loads

## Testing
- `pytest`
- `npm run lint` *(fails: 372 errors in unrelated files)*
- `npx eslint src/modules/crm/organizations/OrganizationDetails.vue src/modules/crm/organizations/js/organizationApi.js`

------
https://chatgpt.com/codex/tasks/task_e_689813362ec08329a888522182dcef8f