### PR TITLE
Link projects with organizations and show org items

### DIFF
--- a/api/src/modules/crm/serializers.py
+++ b/api/src/modules/crm/serializers.py
@@ -215,7 +215,7 @@ class ProjectSerializer(serializers.ModelSerializer):
     manager_id = serializers.IntegerField(write_only=True, required=False, allow_null=True)
     memberships = ProjectMemberSerializer(many=True, read_only=True)
     organization = OrganizationSerializer(read_only=True)
-    organization_id = serializers.IntegerField(write_only=True, required=False)
+    organization_id = serializers.IntegerField(write_only=True, required=False, allow_null=True)
 
     # Новые поля для статусов и приоритетов
     status_ref = ProjectStatusSerializer(read_only=True)
@@ -270,15 +270,23 @@ class ProjectSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         user = self.context['request'].user
         organization_id = validated_data.pop('organization_id', None)
-        if not organization_id:
-            raise serializers.ValidationError('organization_id is required')
-        try:
-            organization = Organization.objects.get(id=organization_id)
-        except Organization.DoesNotExist:
-            raise serializers.ValidationError('Организация не найдена')
+        organization = None
 
-        if not (organization.owner == user or OrganizationMember.objects.filter(organization=organization, user=user, status='accepted').exists()):
-            raise serializers.ValidationError('Вы не являетесь участником организации')
+        if organization_id:
+            try:
+                organization = Organization.objects.get(id=organization_id)
+            except Organization.DoesNotExist:
+                raise serializers.ValidationError('Организация не найдена')
+
+            if not (
+                organization.owner == user or
+                OrganizationMember.objects.filter(
+                    organization=organization,
+                    user=user,
+                    status='accepted'
+                ).exists()
+            ):
+                raise serializers.ValidationError('Вы не являетесь участником организации')
 
         validated_data['owner'] = user
         validated_data['organization'] = organization
@@ -421,7 +429,7 @@ class TaskSerializer(serializers.ModelSerializer):
     assignee_id = serializers.IntegerField(write_only=True, required=False, allow_null=True)
     project_id = serializers.IntegerField(write_only=True)
     organization = OrganizationSerializer(read_only=True)
-    organization_id = serializers.IntegerField(write_only=True)
+    organization_id = serializers.IntegerField(write_only=True, required=False, allow_null=True)
     parent = TaskListSerializer(read_only=True)
     parent_id = serializers.IntegerField(write_only=True, required=False, allow_null=True)
     subtasks = TaskListSerializer(many=True, read_only=True)
@@ -475,20 +483,41 @@ class TaskSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         user = self.context['request'].user
         organization_id = validated_data.pop('organization_id', None)
-        if not organization_id:
-            raise serializers.ValidationError('organization_id is required')
-        try:
-            organization = Organization.objects.get(id=organization_id)
-        except Organization.DoesNotExist:
-            raise serializers.ValidationError('Организация не найдена')
-        if not (organization.owner == user or OrganizationMember.objects.filter(organization=organization, user=user, status='accepted').exists()):
-            raise serializers.ValidationError('Вы не являетесь участником организации')
-
         project_id = validated_data.pop('project_id', None)
+
         try:
-            project = Project.objects.get(id=project_id, organization=organization)
+            project = Project.objects.get(id=project_id)
         except Project.DoesNotExist:
-            raise serializers.ValidationError('Проект не найден в организации')
+            raise serializers.ValidationError('Проект не найден')
+
+        organization = None
+        if organization_id:
+            try:
+                organization = Organization.objects.get(id=organization_id)
+            except Organization.DoesNotExist:
+                raise serializers.ValidationError('Организация не найдена')
+        else:
+            organization = project.organization
+
+        if organization:
+            if project.organization_id != organization.id:
+                raise serializers.ValidationError('Проект не найден в организации')
+            if not (
+                organization.owner == user or
+                OrganizationMember.objects.filter(
+                    organization=organization,
+                    user=user,
+                    status='accepted'
+                ).exists()
+            ):
+                raise serializers.ValidationError('Вы не являетесь участником организации')
+        else:
+            if not (
+                project.owner_id == user.id or
+                project.manager_id == user.id or
+                project.team_members.filter(id=user.id).exists()
+            ):
+                raise serializers.ValidationError('Нет доступа к проекту')
 
         validated_data['project'] = project
         validated_data['creator'] = user

--- a/api/src/modules/crm/views.py
+++ b/api/src/modules/crm/views.py
@@ -394,7 +394,7 @@ class ProjectViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
     queryset = Project.objects.all()
     permission_classes = [IsAuthenticated]
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
-    filterset_fields = ['status', 'priority', 'owner', 'manager']
+    filterset_fields = ['status', 'priority', 'owner', 'manager', 'organization']
     search_fields = ['name', 'description']
     ordering_fields = ['created_at', 'start_date', 'end_date', 'priority']
     ordering = ['-created_at']
@@ -414,24 +414,24 @@ class ProjectViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
 
         queryset = super().get_queryset()
 
-        # Показываем только проекты организаций, где пользователь является владельцем
-        # или принятым участником
+        # Показываем проекты организаций, где пользователь владелец или участник,
+        # а также проекты без организации
         queryset = queryset.filter(
             Q(organization__owner=user) |
-            Q(organization__memberships__user=user, organization__memberships__status='accepted')
-        ).filter(
-            Q(owner=user) |
-            Q(manager=user) |
-            Q(team_members=user)
-        ).distinct()
+            Q(organization__memberships__user=user, organization__memberships__status='accepted') |
+            Q(organization__isnull=True)
+        )
 
         # Дополнительный фильтр "Мои проекты" (оставляем для совместимости)
         my_projects = self.request.query_params.get('my_projects', None)
-        if my_projects and my_projects.lower() == 'false':
-            # Если явно указано false, показываем все доступные проекты
-            queryset = super().get_queryset()
+        if not (my_projects and my_projects.lower() == 'false'):
+            queryset = queryset.filter(
+                Q(owner=user) |
+                Q(manager=user) |
+                Q(team_members=user)
+            )
 
-        return queryset
+        return queryset.distinct()
 
     @action(detail=True, methods=['post'])
     def add_member(self, request, pk=None):
@@ -515,7 +515,7 @@ class TaskViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
     queryset = Task.objects.all()
     permission_classes = [IsAuthenticated]
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
-    filterset_fields = ['status', 'priority', 'project', 'assignee', 'creator', 'parent']
+    filterset_fields = ['status', 'priority', 'project', 'assignee', 'creator', 'parent', 'organization']
     search_fields = ['title', 'description']
     ordering_fields = ['created_at', 'due_date', 'priority', 'kanban_order']
     ordering = ['kanban_order', '-created_at']
@@ -540,10 +540,11 @@ class TaskViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
         queryset = super().get_queryset()
 
         # Ограничиваем задачи организациями, где пользователь владелец
-        # или принятый участник
+        # или принятый участник, а также задачи без организации
         queryset = queryset.filter(
             Q(organization__owner=user) |
-            Q(organization__memberships__user=user, organization__memberships__status='accepted')
+            Q(organization__memberships__user=user, organization__memberships__status='accepted') |
+            Q(organization__isnull=True)
         )
 
         # Параметр "Мои задачи"

--- a/client/src/modules/crm/organizations/OrganizationDetails.vue
+++ b/client/src/modules/crm/organizations/OrganizationDetails.vue
@@ -239,8 +239,28 @@
         <div v-if="loadingProjects"><div class="skeleton skeleton--row"></div></div>
         <div v-else>
           <ul>
-            <li v-for="p in projects" :key="p.id">{{ p.name }}</li>
+            <li v-for="p in projects" :key="p.id">
+              <router-link :to="{ name: 'ProjectDetail', params: { id: p.id } }">{{ p.name }}</router-link>
+            </li>
             <li v-if="projects.length === 0" class="muted">Проектов пока нет</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Задачи -->
+    <section class="card">
+      <header class="card__header">
+        <h3 class="card__title">Задачи</h3>
+      </header>
+      <div class="card__body">
+        <div v-if="loadingTasks"><div class="skeleton skeleton--row"></div></div>
+        <div v-else>
+          <ul>
+            <li v-for="t in tasks" :key="t.id">
+              <router-link :to="{ name: 'TaskDetail', params: { id: t.id } }">{{ t.title }}</router-link>
+            </li>
+            <li v-if="tasks.length === 0" class="muted">Задач пока нет</li>
           </ul>
         </div>
       </div>
@@ -280,10 +300,12 @@ export default {
     const myMember = ref(null);
     const isParticipant = ref(false);
     const projects = ref([]);
+    const tasks = ref([]);
 
     const loadingOrg = ref(false);
     const loadingMembers = ref(false);
     const loadingProjects = ref(false);
+    const loadingTasks = ref(false);
 
     const showInvite = ref(false);
     const inviting = ref(false);
@@ -316,6 +338,14 @@ export default {
         const resp = await OrganizationApi.getProjects(id);
         projects.value = resp?.data?.results || resp?.data || [];
       } finally { loadingProjects.value = false; }
+    };
+
+    const loadTasks = async () => {
+      loadingTasks.value = true;
+      try {
+        const resp = await OrganizationApi.getTasks(id);
+        tasks.value = resp?.data?.results || resp?.data || [];
+      } finally { loadingTasks.value = false; }
     };
 
     // ====== ПРАВА (как в списке) ======
@@ -457,15 +487,15 @@ export default {
     );
 
     onMounted(async () => {
-      await Promise.all([loadOrg(), loadMembers(), loadProjects()]);
+      await Promise.all([loadOrg(), loadMembers(), loadProjects(), loadTasks()]);
       editForm.value = { ...org.value };
     });
 
     return {
       id,
 
-      org, members, projects,
-      loadingOrg, loadingMembers, loadingProjects,
+      org, members, projects, tasks,
+      loadingOrg, loadingMembers, loadingProjects, loadingTasks,
       showInvite, inviting, onInviteSubmit,
 
       // права

--- a/client/src/modules/crm/organizations/js/organizationApi.js
+++ b/client/src/modules/crm/organizations/js/organizationApi.js
@@ -45,6 +45,7 @@ class OrganizationApi {
     return await this.client.post(`/crm/organizations/${id}/leave/`);
   }
   async getProjects(orgId) { return await this.client.get(`/crm/projects/`, { params: { organization: orgId } }); }
+  async getTasks(orgId) { return await this.client.get(`/crm/tasks/`, { params: { organization: orgId } }); }
 
   // invites
   async inviteToOrganization(orgId, data) { return await this.client.post(`/crm/organizations/${orgId}/invite/`, data); }


### PR DESCRIPTION
## Summary
- Allow creating projects and tasks without organization and filter queries accordingly
- Expose organization filter for projects and tasks
- Show organization's projects and tasks in details page with navigation links

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898bd94a4fc8329918b68d80ee9ba67