### PR TITLE
feat: link projects and tasks with organization members

### DIFF
--- a/client/src/modules/crm/project-management/KanbanBoard.vue
+++ b/client/src/modules/crm/project-management/KanbanBoard.vue
@@ -369,6 +369,7 @@
 <script>
 import { Modal } from 'bootstrap'
 import projectManagementApi from '@/modules/crm/project-management/js/projectManagementApi.js'
+import OrganizationApi from '@/modules/crm/organizations/js/organizationApi.js'
 import { useNotifications } from '@/modules/lms/composables/useNotifications'
 import { getAvatarUrl } from '@/modules/cms/js/avatarUtils.js'
 
@@ -439,12 +440,18 @@ export default {
     },
 
   },
-  
+
+  watch: {
+    'currentTask.project_id'(val) {
+      this.loadUsersForProject(val)
+    }
+  },
+
       async mounted() {
     console.log('KanbanBoard mounted')
     
     await this.loadProjects()
-    await this.loadUsers()
+    await this.loadAllUsers()
     await this.loadTaskStatuses()  // Теперь это также инициализирует колонки
     await this.loadTaskPriorities()
     this.loadKanbanData()
@@ -498,12 +505,32 @@ export default {
       }
     },
     
-    async loadUsers() {
+    async loadAllUsers() {
       try {
         const response = await projectManagementApi.getUsers()
-        this.users = Array.isArray(response.data) ? response.data : []
+        this.users = Array.isArray(response.data) ? response.data : (response.data?.results || [])
       } catch (error) {
         console.error('Ошибка загрузки пользователей:', error)
+        this.users = []
+      }
+    },
+
+    async loadUsersForProject(projectId) {
+      try {
+        if (projectId) {
+          const proj = this.projects.find(p => p.id === projectId)
+          const orgId = proj?.organization?.id
+          if (orgId) {
+            const resp = await OrganizationApi.getOrganizationMembers(orgId)
+            const members = Array.isArray(resp.data.results) ? resp.data.results : (resp.data || [])
+            this.users = members.map(m => m.user || m).filter(u => u && u.id)
+            return
+          }
+        }
+        await this.loadAllUsers()
+      } catch (error) {
+        console.error('Ошибка загрузки пользователей:', error)
+        alert(error?.response?.data?.detail || 'Ошибка')
         this.users = []
       }
     },
@@ -832,9 +859,10 @@ export default {
         due_date: '',
         estimated_hours: null
       }
-      
-      const modal = new Modal(document.getElementById('taskModal'))
-      modal.show()
+      this.loadUsersForProject(this.currentTask.project_id).then(() => {
+        const modal = new Modal(document.getElementById('taskModal'))
+        modal.show()
+      })
     },
 
     createTaskForStatus(status) {
@@ -853,9 +881,10 @@ export default {
         due_date: '',
         estimated_hours: null
       }
-      
-      const modal = new Modal(document.getElementById('taskModal'))
-      modal.show()
+      this.loadUsersForProject(this.currentTask.project_id).then(() => {
+        const modal = new Modal(document.getElementById('taskModal'))
+        modal.show()
+      })
     },
     
     editTask(task) {
@@ -871,9 +900,10 @@ export default {
         due_date: task.due_date ? this.formatDateTimeLocal(new Date(task.due_date)) : '',
         estimated_hours: task.estimated_hours
       }
-      
-      const modal = new Modal(document.getElementById('taskModal'))
-      modal.show()
+      this.loadUsersForProject(this.currentTask.project_id).then(() => {
+        const modal = new Modal(document.getElementById('taskModal'))
+        modal.show()
+      })
     },
     
     editTaskFromView() {
@@ -1306,20 +1336,21 @@ export default {
       // Устанавливаем значения по умолчанию из API
       const defaultPriority = this.taskPriorities.find(p => p.is_default) || this.taskPriorities[0]
       
-      this.currentTask = {
-        title: '',
-        description: '',
-        project_id: '',
-        assignee_id: '',
-        status: status,
-        priority: defaultPriority ? defaultPriority.code : 'medium',
-        due_date: '',
-        estimated_hours: null
-      }
-      
+    this.currentTask = {
+      title: '',
+      description: '',
+      project_id: '',
+      assignee_id: '',
+      status: status,
+      priority: defaultPriority ? defaultPriority.code : 'medium',
+      due_date: '',
+      estimated_hours: null
+    }
+    this.loadUsersForProject(this.currentTask.project_id).then(() => {
       const modal = new Modal(document.getElementById('taskModal'))
       modal.show()
-    },
+    })
+  },
     
     // Новые обработчики drag and drop
     handleDragOver(event, status) {

--- a/client/src/modules/crm/project-management/ProjectDetail.vue
+++ b/client/src/modules/crm/project-management/ProjectDetail.vue
@@ -610,6 +610,7 @@
 import { Modal } from 'bootstrap'
 import { Edit, Trash2, Plus, Home, Info, PieChart, ListTodo, Calendar, Clock, Users, CheckCircle, AlertTriangle, UserPlus, UserMinus, GitBranch } from 'lucide-vue-next'
 import projectManagementApi from '@/modules/crm/project-management/js/projectManagementApi.js'
+import OrganizationApi from '@/modules/crm/organizations/js/organizationApi.js'
 import { useNotifications } from '@/modules/lms/composables/useNotifications'
 import { getAvatarUrl } from '@/modules/cms/js/avatarUtils.js'
 import ProjectTasksTree from './ProjectTasksTree.vue'
@@ -681,11 +682,8 @@ export default {
     }
   },
   async mounted() {
-    await Promise.all([
-      this.loadUsers(),
-      this.loadStatusesAndPriorities()
-    ])
-    this.loadProjectData()
+    await this.loadStatusesAndPriorities()
+    await this.loadProjectData()
   },
   computed: {
     availableUsers() {
@@ -830,6 +828,9 @@ export default {
   watch: {
     '$route'() {
       this.loadProjectData()
+    },
+    'project.organization.id'() {
+      this.loadUsers()
     }
   },
   methods: {
@@ -850,6 +851,7 @@ export default {
         // Загружаем данные проекта
         const response = await projectManagementApi.getProject(projectId)
         this.project = response.data
+        await this.loadUsers()
 
         // Загружаем задачи проекта
         const tasksResponse = await projectManagementApi.getProjectTasks(projectId)
@@ -867,12 +869,16 @@ export default {
 
     async loadUsers() {
       try {
-        const response = await projectManagementApi.getUsers()
-        const users = Array.isArray(response.data.results) ? response.data.results : 
-                      Array.isArray(response.data) ? response.data : []
-        
-        // Фильтруем только валидных пользователей
-        this.users = users.filter(user => user && user.id)
+        if (this.project?.organization?.id) {
+          const resp = await OrganizationApi.getOrganizationMembers(this.project.organization.id)
+          const members = Array.isArray(resp.data.results) ? resp.data.results : (resp.data || [])
+          this.users = members.map(m => m.user || m).filter(u => u && u.id)
+        } else {
+          const response = await projectManagementApi.getUsers()
+          const users = Array.isArray(response.data.results) ? response.data.results :
+                        (Array.isArray(response.data) ? response.data : [])
+          this.users = users.filter(user => user && user.id)
+        }
       } catch (error) {
         console.error('Ошибка загрузки пользователей:', error)
         this.users = []

--- a/client/src/modules/crm/project-management/TaskCalendar.vue
+++ b/client/src/modules/crm/project-management/TaskCalendar.vue
@@ -457,6 +457,7 @@
 import { ChevronLeft, ChevronRight, Calendar, ChevronsLeft, ChevronsRight } from 'lucide-vue-next'
 import { Modal } from 'bootstrap'
 import projectManagementApi from '@/modules/crm/project-management/js/projectManagementApi.js'
+import OrganizationApi from '@/modules/crm/organizations/js/organizationApi.js'
 import { useNotifications } from '@/modules/lms/composables/useNotifications'
 
 export default {
@@ -591,10 +592,16 @@ export default {
       return Array.from(uniqueProjects.values())
     }
   },
-  
+
+  watch: {
+    'currentTask.project_id'(val) {
+      this.loadUsersForProject(val)
+    }
+  },
+
   async mounted() {
     await this.loadProjects()
-    await this.loadUsers()
+    await this.loadAllUsers()
     await this.loadTaskStatuses()
     await this.loadTaskPriorities()
     await this.loadProjectStatuses()
@@ -637,12 +644,32 @@ export default {
       }
     },
     
-    async loadUsers() {
+    async loadAllUsers() {
       try {
         const response = await projectManagementApi.getUsers()
-        this.users = Array.isArray(response.data) ? response.data : []
+        this.users = Array.isArray(response.data) ? response.data : (response.data?.results || [])
       } catch (error) {
         console.error('Ошибка загрузки пользователей:', error)
+        this.users = []
+      }
+    },
+
+    async loadUsersForProject(projectId) {
+      try {
+        if (projectId) {
+          const proj = this.projects.find(p => p.id === projectId)
+          const orgId = proj?.organization?.id
+          if (orgId) {
+            const resp = await OrganizationApi.getOrganizationMembers(orgId)
+            const members = Array.isArray(resp.data.results) ? resp.data.results : (resp.data || [])
+            this.users = members.map(m => m.user || m).filter(u => u && u.id)
+            return
+          }
+        }
+        await this.loadAllUsers()
+      } catch (error) {
+        console.error('Ошибка загрузки пользователей:', error)
+        alert(error?.response?.data?.detail || 'Ошибка')
         this.users = []
       }
     },
@@ -942,9 +969,10 @@ export default {
         due_date: '',
         estimated_hours: null
       }
-      
-      const modal = new Modal(document.getElementById('taskModal'))
-      modal.show()
+      this.loadUsersForProject(this.currentTask.project_id).then(() => {
+        const modal = new Modal(document.getElementById('taskModal'))
+        modal.show()
+      })
     },
     
     editTask(task) {
@@ -961,14 +989,15 @@ export default {
         due_date: task.due_date ? this.formatDateTimeLocal(task.due_date) : '',
         estimated_hours: task.estimated_hours
       }
-      
-      // Закрываем модальное окно просмотра
-      const viewModal = Modal.getInstance(document.getElementById('taskViewModal'))
-      if (viewModal) viewModal.hide()
-      
-      // Открываем модальное окно редактирования
-      const editModal = new Modal(document.getElementById('taskModal'))
-      editModal.show()
+      this.loadUsersForProject(this.currentTask.project_id).then(() => {
+        // Закрываем модальное окно просмотра
+        const viewModal = Modal.getInstance(document.getElementById('taskViewModal'))
+        if (viewModal) viewModal.hide()
+
+        // Открываем модальное окно редактирования
+        const editModal = new Modal(document.getElementById('taskModal'))
+        editModal.show()
+      })
     },
     
     viewTask(taskEvent) {

--- a/client/src/modules/crm/project-management/TasksList.vue
+++ b/client/src/modules/crm/project-management/TasksList.vue
@@ -502,6 +502,7 @@
 import { Modal } from 'bootstrap'
 import { Edit, Trash2, Plus } from 'lucide-vue-next'
 import projectManagementApi from '@/modules/crm/project-management/js/projectManagementApi.js'
+import OrganizationApi from '@/modules/crm/organizations/js/organizationApi.js'
 import { useNotifications } from '@/modules/lms/composables/useNotifications'
 import { getAvatarUrl } from '@/modules/cms/js/avatarUtils.js'
 
@@ -568,7 +569,7 @@ export default {
   
   async mounted() {
     await this.loadProjects()
-    await this.loadUsers()
+    await this.loadAllUsers()
     await this.loadStatusesAndPriorities()
     this.loadTasks()
     
@@ -587,7 +588,13 @@ export default {
       }
     }
   },
-  
+
+  watch: {
+    'currentTask.project_id'(val) {
+      this.loadUsersForProject(val)
+    }
+  },
+
   methods: {
     async loadProjects() {
       try {
@@ -600,13 +607,33 @@ export default {
       }
     },
     
-    async loadUsers() {
+    async loadAllUsers() {
       try {
         const response = await projectManagementApi.getUsers()
-        this.users = Array.isArray(response.data.results) ? response.data.results : 
-                     Array.isArray(response.data) ? response.data : []
+        this.users = Array.isArray(response.data.results) ? response.data.results :
+                     (Array.isArray(response.data) ? response.data : [])
       } catch (error) {
         console.error('Ошибка загрузки пользователей:', error)
+        this.users = []
+      }
+    },
+
+    async loadUsersForProject(projectId) {
+      try {
+        if (projectId) {
+          const proj = this.projects.find(p => p.id === projectId)
+          const orgId = proj?.organization?.id
+          if (orgId) {
+            const resp = await OrganizationApi.getOrganizationMembers(orgId)
+            const members = Array.isArray(resp.data.results) ? resp.data.results : (resp.data || [])
+            this.users = members.map(m => m.user || m).filter(u => u && u.id)
+            return
+          }
+        }
+        await this.loadAllUsers()
+      } catch (error) {
+        console.error('Ошибка загрузки пользователей:', error)
+        alert(error?.response?.data?.detail || 'Ошибка')
         this.users = []
       }
     },
@@ -768,6 +795,8 @@ export default {
         parent_id: parentTask ? parentTask.id : null
       }
 
+      await this.loadUsersForProject(this.currentTask.project_id)
+
       const modal = new Modal(document.getElementById('taskModal'))
       modal.show()
     },
@@ -791,7 +820,9 @@ export default {
         estimated_hours: task.estimated_hours,
         parent_id: task.parent || null
       }
-      
+
+      await this.loadUsersForProject(this.currentTask.project_id)
+
       const modal = new Modal(document.getElementById('taskModal'))
       modal.show()
     },

--- a/client/src/modules/crm/strategic-projects/ProjectEdit.vue
+++ b/client/src/modules/crm/strategic-projects/ProjectEdit.vue
@@ -185,6 +185,36 @@
                     </div>
                   </div>
                 </div>
+                
+                <div class="row">
+                  <div class="col-md-4">
+                    <div class="form-group">
+                      <label class="form-label">
+                        <i class="fas fa-building mr-2"></i>
+                        Организация
+                      </label>
+                      <div class="select-wrapper">
+                        <select v-model="project.organization_id" class="form-control custom-select">
+                          <option :value="null">—</option>
+                          <option v-for="org in organizations" :key="org.id" :value="org.id">
+                            {{ org.name }}
+                          </option>
+                        </select>
+                        <div class="select-arrow">
+                          <i class="fas fa-chevron-down"></i>
+                        </div>
+                      </div>
+                      <small v-if="loadingOrgs" class="form-text text-info">
+                        <i class="fas fa-spinner fa-spin mr-1"></i>
+                        Загрузка организаций...
+                      </small>
+                      <small v-else-if="organizations.length === 0" class="form-text text-warning">
+                        <i class="fas fa-exclamation-triangle mr-1"></i>
+                        Организации не найдены
+                      </small>
+                    </div>
+                  </div>
+                </div>
 
                 <div class="row">
                   <div class="col-md-4">
@@ -492,6 +522,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { apiClient } from '@/js/api/manager'
+import OrganizationApi from '@/modules/crm/organizations/js/organizationApi.js'
 
 export default {
   name: 'ProjectEdit',
@@ -514,10 +545,13 @@ export default {
       requires_budget: false,
       total_budget: null,
       stages: [],
-      status: 'draft'
+      status: 'draft',
+      organization_id: null
     })
-    
+
     const users = ref([])
+    const organizations = ref([])
+    const loadingOrgs = ref(false)
     const saving = ref(false)
     const submitting = ref(false)
     const loadingUsers = ref(false)
@@ -590,7 +624,22 @@ export default {
       }
       return icons[status] || 'fas fa-question-circle'
     }
-    
+
+    // Загрузка организаций
+    const loadOrganizations = async () => {
+      loadingOrgs.value = true
+      try {
+        const resp = await OrganizationApi.getOrganizations()
+        const list = resp?.data?.results || resp?.data || []
+        organizations.value = list.filter(org => org?.my_role)
+      } catch (e) {
+        console.error('Ошибка загрузки организаций:', e)
+        alert(e?.response?.data?.detail || 'Ошибка')
+      } finally {
+        loadingOrgs.value = false
+      }
+    }
+
     // Загрузка пользователей
     const loadUsers = async () => {
       loadingUsers.value = true
@@ -682,7 +731,9 @@ export default {
       try {
         const response = await apiClient.get(`/crm/strategic-projects/strategic-projects/${projectId}/`)
         project.value = response.data
-        
+        project.value.organization_id = response.data.organization?.id || null
+        delete project.value.organization
+
         // Убеждаемся, что массивы инициализированы
         if (!project.value.planned_results) {
           project.value.planned_results = []
@@ -741,16 +792,20 @@ export default {
       
       saving.value = true
       try {
+        const data = { ...project.value }
+        if (!data.organization_id) {
+          delete data.organization_id
+        }
         let response
         if (isEditMode.value) {
           response = await apiClient.patch(
             `/crm/strategic-projects/strategic-projects/${projectId}/`,
-            project.value
+            data
           )
         } else {
           response = await apiClient.post(
             '/crm/strategic-projects/strategic-projects/',
-            project.value
+            data
           )
         }
         
@@ -984,9 +1039,7 @@ export default {
     
     // Загрузка данных при монтировании
     onMounted(async () => {
-      console.log('Начинаем загрузку пользователей...')
-      await loadUsers()
-      console.log('Загружено пользователей:', users.value.length, users.value)
+      await Promise.all([loadUsers(), loadOrganizations()])
       await loadProject()
       initializeNewProject()
     })
@@ -994,7 +1047,9 @@ export default {
     return {
       project,
       users,
+      organizations,
       loadingUsers,
+      loadingOrgs,
       isEditMode,
       saving,
       submitting,


### PR DESCRIPTION
## Summary
- allow selecting an organization when creating or editing projects
- filter task assignee options by a project's organization members across task forms

## Testing
- `npm run lint` *(fails: The template requires child element, no-unused-vars, etc)*

------
https://chatgpt.com/codex/tasks/task_e_6898c326b7448329a401edae478f4239