### PR TITLE
feat(crm): link projects with organizations

### DIFF
--- a/client/src/modules/crm/organizations/js/organizationApi.js
+++ b/client/src/modules/crm/organizations/js/organizationApi.js
@@ -17,7 +17,15 @@ class OrganizationApi {
   }
 
   // list
-  async getOrganizations(params = {}) { return await this.client.get('/crm/organizations/', { params }); }
+  async getOrganizations(params = {}) {
+    return await this.client.get('/crm/organizations/', { params })
+  }
+
+  async getMyOrganizations(params = {}) {
+    return await this.client.get('/crm/organizations/', {
+      params: { my: true, page_size: 1000, ...params }
+    })
+  }
   // details
   async getOrganization(id) { return await this.client.get(`/crm/organizations/${id}/`); }
   // create/update/delete
@@ -34,7 +42,9 @@ class OrganizationApi {
   async archiveOrganization(id) { return await this.client.post(`/crm/organizations/${id}/archive`); }
 
   // members & projects
-  async getOrganizationMembers(id) { return await this.client.get(`/crm/organizations/${id}/members/`); }
+  async getOrganizationMembers(id, params = {}) {
+    return await this.client.get(`/crm/organizations/${id}/members/`, { params })
+  }
   async updateOrganizationMember(orgId, userId, data) { return await this.client.patch(`/crm/organizations/${orgId}/members/${userId}/`, data); }
   async removeOrganizationMember(id, userId) {
     // если на бэке есть отдельная ручка — подставить; иначе временный эндпоинт недоступен

--- a/client/src/modules/crm/project-management/ProjectDetail.vue
+++ b/client/src/modules/crm/project-management/ProjectDetail.vue
@@ -397,6 +397,16 @@
                 </div>
               </div>
               <div class="mb-3">
+                <label class="form-label">Организация</label>
+                <select class="form-select" v-model="currentProject.organization_id" :disabled="loadingOrganizations">
+                  <option :value="null">—</option>
+                  <option v-if="loadingOrganizations">Загрузка...</option>
+                  <option v-else v-for="org in organizations" :key="org.id" :value="org.id">
+                    {{ org.name }}
+                  </option>
+                </select>
+              </div>
+              <div class="mb-3">
                 <label class="form-label">Цвет проекта</label>
                 <input type="color" class="form-control form-control-color" v-model="currentProject.color">
               </div>
@@ -434,7 +444,7 @@
                 <div class="col-md-4">
                   <div class="mb-3">
                     <label class="form-label">Исполнитель</label>
-                    <select class="form-select" v-model="currentTask.assignee_id">
+                    <select class="form-select" v-model="currentTask.assignee_id" :disabled="loadingUsers">
                       <option value="">Не назначен</option>
                       <option v-for="user in users" :key="user.id" :value="user.id">
                         {{ getUserDisplayName(user) }}
@@ -665,7 +675,8 @@ export default {
         end_date: '',
         status: 'planning',
         priority: 'medium',
-        color: '#007bff'
+        color: '#007bff',
+        organization_id: null
       },
       isEditingTask: false,
       isEditingProject: false,
@@ -675,6 +686,9 @@ export default {
       taskStatuses: [],
       taskPriorities: [],
       loadingStatuses: false,
+      organizations: [],
+      loadingOrganizations: false,
+      loadingUsers: false,
       // Управление командой проекта
       selectedUserId: '',
       selectedRole: 'member',
@@ -868,6 +882,7 @@ export default {
     },
 
     async loadUsers() {
+      this.loadingUsers = true
       try {
         if (this.project?.organization?.id) {
           const resp = await OrganizationApi.getOrganizationMembers(this.project.organization.id)
@@ -881,7 +896,27 @@ export default {
         }
       } catch (error) {
         console.error('Ошибка загрузки пользователей:', error)
+        alert(error?.response?.data?.detail || 'Ошибка')
         this.users = []
+      } finally {
+        this.loadingUsers = false
+      }
+    },
+
+    async loadOrganizations() {
+      this.loadingOrganizations = true
+      try {
+        const res = await OrganizationApi.getMyOrganizations()
+        const data = Array.isArray(res.data?.results)
+          ? res.data.results
+          : (Array.isArray(res.data) ? res.data : [])
+        this.organizations = data
+      } catch (e) {
+        console.error('Ошибка загрузки организаций:', e)
+        alert(e?.response?.data?.detail || 'Ошибка')
+        this.organizations = []
+      } finally {
+        this.loadingOrganizations = false
       }
     },
 
@@ -944,10 +979,11 @@ export default {
       }
     },
 
-    editProject() {
+    async editProject() {
       if (!this.project) return
-      
+
       this.isEditingProject = true
+      await this.loadOrganizations()
       this.currentProject = {
         id: this.project.id,
         name: this.project.name,
@@ -956,15 +992,18 @@ export default {
         end_date: this.project.end_date || '',
         status: this.project.status,
         priority: this.project.priority,
-        color: this.project.color
+        color: this.project.color,
+        organization_id: this.project.organization?.id ?? null
       }
-      
+
       const modal = new Modal(document.getElementById('projectModal'))
       modal.show()
     },
 
-    createTask(parentTask = null) {
+    async createTask(parentTask = null) {
       if (!this.project) return
+
+      await this.loadUsers()
 
       // Устанавливаем значения по умолчанию из загруженных данных
       const defaultTaskStatus = this.taskStatuses.find(s => s.is_default) || this.taskStatuses[0]
@@ -992,8 +1031,9 @@ export default {
       this.createTask(task)
     },
 
-    editTask(task) {
+    async editTask(task) {
       this.isEditingTask = true
+      await this.loadUsers()
       this.currentTask = {
         id: task.id,
         title: task.title,
@@ -1023,7 +1063,8 @@ export default {
           ...this.currentProject,
           // Конвертируем пустые строки в null для дат
           start_date: this.currentProject.start_date || null,
-          end_date: this.currentProject.end_date || null
+          end_date: this.currentProject.end_date || null,
+          organization_id: this.currentProject.organization_id ?? null
         }
         
         await projectManagementApi.updateProject(projectData.id, projectData)

--- a/client/src/modules/crm/project-management/ProjectsList.vue
+++ b/client/src/modules/crm/project-management/ProjectsList.vue
@@ -246,6 +246,20 @@
                   </select>
                 </div>
               </div>
+              <div class="row g-3 mb-4">
+                <div class="col-md-6">
+                  <label class="form-label fw-bold">Организация</label>
+                  <select class="form-select"
+                          v-model="currentProject.organization_id"
+                          :disabled="loadingOrganizations">
+                    <option :value="null">—</option>
+                    <option v-if="loadingOrganizations">Загрузка...</option>
+                    <option v-else v-for="org in organizations" :key="org.id" :value="org.id">
+                      {{ org.name }}
+                    </option>
+                  </select>
+                </div>
+              </div>
               <div class="mb-4">
                 <label class="form-label fw-bold">Цвет проекта</label>
                 <div class="d-flex align-items-center gap-2">
@@ -273,6 +287,7 @@ import { Edit, Trash2 } from 'lucide-vue-next'
 import projectManagementApi from '@/modules/crm/project-management/js/projectManagementApi.js'
 import { useNotifications } from '@/modules/lms/composables/useNotifications'
 import { getAvatarUrl } from '@/modules/cms/js/avatarUtils.js'
+import OrganizationApi from '@/modules/crm/organizations/js/organizationApi.js'
 
 export default {
   name: 'ProjectsList',
@@ -314,14 +329,17 @@ export default {
         end_date: '',
         status: 'planning',
         priority: 'medium',
-        color: '#007bff'
+        color: '#007bff',
+        organization_id: null
       },
       isEditing: false,
       searchTimeout: null,
       // Динамические данные для статусов и приоритетов
       projectStatuses: [],
       projectPriorities: [],
-      loadingStatuses: false
+      loadingStatuses: false,
+      organizations: [],
+      loadingOrganizations: false
     }
   },
   
@@ -428,7 +446,24 @@ export default {
         this.loadingStatuses = false
       }
     },
-    
+
+    async loadOrganizations() {
+      this.loadingOrganizations = true
+      try {
+        const res = await OrganizationApi.getMyOrganizations()
+        const data = Array.isArray(res.data?.results)
+          ? res.data.results
+          : (Array.isArray(res.data) ? res.data : [])
+        this.organizations = data
+      } catch (e) {
+        console.error('Ошибка загрузки организаций:', e)
+        alert(e?.response?.data?.detail || 'Ошибка')
+        this.organizations = []
+      } finally {
+        this.loadingOrganizations = false
+      }
+    },
+
     changePage(page) {
       if (page >= 1 && page <= this.pagination.total_pages) {
         this.pagination.current_page = page
@@ -456,14 +491,15 @@ export default {
     
     async createProject() {
       this.isEditing = false
-      
+
       // Обновляем статусы и приоритеты перед созданием проекта
       await this.refreshStatusesAndPriorities()
-      
+      await this.loadOrganizations()
+
       // Устанавливаем значения по умолчанию из загруженных данных
       const defaultStatus = this.projectStatuses.find(s => s.is_default) || this.projectStatuses[0]
       const defaultPriority = this.projectPriorities.find(p => p.is_default) || this.projectPriorities[0]
-      
+
       this.currentProject = {
         name: '',
         description: '',
@@ -471,15 +507,17 @@ export default {
         end_date: '',
         status: defaultStatus ? defaultStatus.code : 'planning',
         priority: defaultPriority ? defaultPriority.code : 'medium',
-        color: '#007bff'
+        color: '#007bff',
+        organization_id: null
       }
-      
+
       const modal = new Modal(document.getElementById('projectModal'))
       modal.show()
     },
-    
-    editProject(project) {
+
+    async editProject(project) {
       this.isEditing = true
+      await this.loadOrganizations()
       this.currentProject = {
         id: project.id,
         name: project.name,
@@ -488,9 +526,10 @@ export default {
         end_date: project.end_date,
         status: project.status,
         priority: project.priority,
-        color: project.color
+        color: project.color,
+        organization_id: project.organization?.id ?? null
       }
-      
+
       const modal = new Modal(document.getElementById('projectModal'))
       modal.show()
     },
@@ -502,7 +541,8 @@ export default {
           ...this.currentProject,
           // Конвертируем пустые строки в null для дат
           start_date: this.currentProject.start_date || null,
-          end_date: this.currentProject.end_date || null
+          end_date: this.currentProject.end_date || null,
+          organization_id: this.currentProject.organization_id ?? null
         }
         
         if (this.isEditing) {

--- a/client/src/modules/crm/project-management/TasksList.vue
+++ b/client/src/modules/crm/project-management/TasksList.vue
@@ -48,7 +48,7 @@
           </div>
           <div class="col-lg-2 col-md-3">
             <label class="form-label">Исполнитель</label>
-            <select class="form-select" v-model="filters.assignee" @change="onAssigneeChange">
+            <select class="form-select" v-model="filters.assignee" @change="onAssigneeChange" :disabled="loadingUsers">
               <option value="">Все исполнители</option>
               <option v-for="user in users" :key="user.id" :value="user.id">
                 {{ user.full_name || user.username }}
@@ -257,7 +257,7 @@
               <div class="row g-3 mb-4">
                 <div class="col-md-6">
                   <label class="form-label fw-bold">Исполнитель</label>
-                  <select class="form-select" v-model="currentTask.assignee_id">
+                  <select class="form-select" v-model="currentTask.assignee_id" :disabled="loadingUsers">
                     <option value="">Не назначен</option>
                     <option v-for="user in users" :key="user.id" :value="user.id">
                       {{ user.full_name || `${user.first_name} ${user.last_name}`.trim() || user.username }}
@@ -563,7 +563,8 @@ export default {
       // Динамические данные для статусов и приоритетов
       taskStatuses: [],
       taskPriorities: [],
-      loadingStatuses: false
+      loadingStatuses: false,
+      loadingUsers: false
     }
   },
   
@@ -592,6 +593,10 @@ export default {
   watch: {
     'currentTask.project_id'(val) {
       this.loadUsersForProject(val)
+    },
+    'filters.project'(val) {
+      this.filters.assignee = ''
+      this.loadUsersForProject(val)
     }
   },
 
@@ -608,17 +613,22 @@ export default {
     },
     
     async loadAllUsers() {
+      this.loadingUsers = true
       try {
         const response = await projectManagementApi.getUsers()
         this.users = Array.isArray(response.data.results) ? response.data.results :
                      (Array.isArray(response.data) ? response.data : [])
       } catch (error) {
         console.error('Ошибка загрузки пользователей:', error)
+        alert(error?.response?.data?.detail || 'Ошибка')
         this.users = []
+      } finally {
+        this.loadingUsers = false
       }
     },
 
     async loadUsersForProject(projectId) {
+      this.loadingUsers = true
       try {
         if (projectId) {
           const proj = this.projects.find(p => p.id === projectId)
@@ -635,6 +645,8 @@ export default {
         console.error('Ошибка загрузки пользователей:', error)
         alert(error?.response?.data?.detail || 'Ошибка')
         this.users = []
+      } finally {
+        this.loadingUsers = false
       }
     },
     


### PR DESCRIPTION
## Summary
- add API helpers for fetching user organizations and members
- allow selecting organization in project forms
- filter task assignees by project organization

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 374 errors)


------
https://chatgpt.com/codex/tasks/task_e_6898ed513ad08329ae11487be8237a24