### PR TITLE
feat: support CRM bulk actions for tasks and projects

### DIFF
--- a/api/src/modules/crm/serializers.py
+++ b/api/src/modules/crm/serializers.py
@@ -548,3 +548,26 @@ class TaskKanbanSerializer(serializers.ModelSerializer):
             'id', 'title', 'description', 'project', 'assignee', 'status',
             'priority', 'due_date', 'kanban_order', 'estimated_hours'
         ]
+
+
+class BulkIDsSerializer(serializers.Serializer):
+    """Сериализатор списка ID"""
+    ids = serializers.ListField(child=serializers.IntegerField(min_value=1), allow_empty=False)
+
+
+class BulkUpdateTaskSerializer(BulkIDsSerializer):
+    """Сериализатор массового обновления задач"""
+    status = serializers.ChoiceField(choices=[c[0] for c in Task.TASK_STATUS_CHOICES], required=False)
+    priority = serializers.ChoiceField(choices=[c[0] for c in Task.PRIORITY_CHOICES], required=False)
+    assignee_id = serializers.IntegerField(required=False, allow_null=True)
+    due_date = serializers.DateTimeField(required=False, allow_null=True)
+    project_id = serializers.IntegerField(required=False, allow_null=True)
+
+
+class BulkUpdateProjectSerializer(BulkIDsSerializer):
+    """Сериализатор массового обновления проектов"""
+    status = serializers.ChoiceField(choices=[c[0] for c in Project.PROJECT_STATUS_CHOICES], required=False)
+    priority = serializers.ChoiceField(choices=[c[0] for c in Project.PRIORITY_CHOICES], required=False)
+    manager_id = serializers.IntegerField(required=False, allow_null=True)
+    start_date = serializers.DateField(required=False, allow_null=True)
+    end_date = serializers.DateField(required=False, allow_null=True)

--- a/api/src/modules/crm/tests.py
+++ b/api/src/modules/crm/tests.py
@@ -1,0 +1,50 @@
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.test.utils import override_settings
+
+from .models import Project, Task
+
+
+@override_settings(ROOT_URLCONF="src.config.urls")
+class BulkActionsTestCase(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username='tester', password='pass')
+        self.client.force_authenticate(self.user)
+        self.project1 = Project.objects.create(name='P1', owner=self.user)
+        self.project2 = Project.objects.create(name='P2', owner=self.user)
+        self.task1 = Task.objects.create(title='T1', project=self.project1, creator=self.user)
+        self.task2 = Task.objects.create(title='T2', project=self.project1, creator=self.user)
+        self.task3 = Task.objects.create(title='T3', project=self.project2, creator=self.user)
+
+    def test_bulk_delete_tasks(self):
+        resp = self.client.delete('/crm/tasks/bulk-delete/', {'ids': [self.task1.id, self.task2.id]}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['deleted'], 2)
+        self.assertFalse(Task.objects.filter(id__in=[self.task1.id, self.task2.id]).exists())
+
+    def test_bulk_update_tasks_status(self):
+        resp = self.client.patch('/crm/tasks/bulk-update/', {'ids': [self.task1.id, self.task2.id], 'status': 'done'}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.task1.refresh_from_db()
+        self.task2.refresh_from_db()
+        self.assertEqual(self.task1.status, 'done')
+        self.assertEqual(self.task2.status, 'done')
+
+    def test_bulk_delete_projects(self):
+        resp = self.client.delete('/crm/projects/bulk-delete/', {'ids': [self.project1.id]}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertFalse(Project.objects.filter(id=self.project1.id).exists())
+
+    def test_bulk_update_projects_status(self):
+        resp = self.client.patch('/crm/projects/bulk-update/', {'ids': [self.project2.id], 'status': 'completed'}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.project2.refresh_from_db()
+        self.assertEqual(self.project2.status, 'completed')
+
+    def test_bulk_delete_tasks_limit(self):
+        ids = list(range(1, 1002))
+        resp = self.client.delete('/crm/tasks/bulk-delete/', {'ids': ids}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+

--- a/api/src/modules/crm/views.py
+++ b/api/src/modules/crm/views.py
@@ -21,10 +21,13 @@ from .serializers import (
     TaskSerializer, TaskListSerializer, TaskCalendarSerializer, TaskKanbanSerializer,
     TaskCommentSerializer, TaskAttachmentSerializer, TimeLogSerializer, CRMUserSerializer,
     ProjectStatusSerializer, ProjectPrioritySerializer, TaskStatusSerializer, TaskPrioritySerializer,
-    OrganizationSerializer, OrganizationMemberSerializer, OrganizationInviteSerializer
+    OrganizationSerializer, OrganizationMemberSerializer, OrganizationInviteSerializer,
+    BulkUpdateTaskSerializer, BulkUpdateProjectSerializer
 )
 
 User = get_user_model()
+
+MAX_BULK = 1000
 
 
 class OrganizationViewSet(viewsets.ModelViewSet):
@@ -509,6 +512,51 @@ class ProjectViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
             'progress': round((completed_tasks / total_tasks * 100) if total_tasks > 0 else 0)
         })
 
+    @action(detail=False, methods=['delete'], url_path='bulk-delete')
+    def bulk_delete(self, request, *args, **kwargs):
+        ids = request.data.get('ids') or request.query_params.getlist('ids')
+        if not ids:
+            return Response({'detail': 'ids is required'}, status=status.HTTP_400_BAD_REQUEST)
+        ids = list({int(i) for i in ids if str(i).isdigit()})
+        if not ids:
+            return Response({'detail': 'ids is empty'}, status=status.HTTP_400_BAD_REQUEST)
+        if len(ids) > MAX_BULK:
+            return Response({'detail': f'Max {MAX_BULK} ids per request'}, status=status.HTTP_400_BAD_REQUEST)
+        qs = self.filter_queryset(self.get_queryset()).filter(id__in=ids)
+        with transaction.atomic():
+            deleted_ids = list(qs.values_list('id', flat=True))
+            qs.delete()
+        return Response({'deleted': len(deleted_ids), 'ids': deleted_ids})
+
+    @action(detail=False, methods=['patch'], url_path='bulk-update')
+    def bulk_update(self, request, *args, **kwargs):
+        serializer = BulkUpdateProjectSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        ids = data.pop('ids')
+        if len(ids) > MAX_BULK:
+            return Response({'detail': f'Max {MAX_BULK} ids per request'}, status=status.HTTP_400_BAD_REQUEST)
+        qs = self.filter_queryset(self.get_queryset()).filter(id__in=ids)
+        manager = None
+        manager_present = False
+        if 'manager_id' in data:
+            manager_present = True
+            manager_id = data.pop('manager_id')
+            if manager_id is not None:
+                manager = User.objects.filter(pk=manager_id).first()
+                if manager is None:
+                    return Response({'detail': 'manager not found'}, status=status.HTTP_400_BAD_REQUEST)
+        with transaction.atomic():
+            updated_ids = []
+            for obj in qs.select_for_update():
+                for field, value in data.items():
+                    setattr(obj, field, value)
+                if manager_present:
+                    obj.manager = manager
+                obj.save()
+                updated_ids.append(obj.id)
+        return Response({'updated': len(updated_ids), 'ids': updated_ids})
+
 
 class TaskViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
     """ViewSet для управления задачами"""
@@ -573,6 +621,62 @@ class TaskViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
             )
 
         return queryset
+
+    @action(detail=False, methods=['delete'], url_path='bulk-delete')
+    def bulk_delete(self, request, *args, **kwargs):
+        ids = request.data.get('ids') or request.query_params.getlist('ids')
+        if not ids:
+            return Response({'detail': 'ids is required'}, status=status.HTTP_400_BAD_REQUEST)
+        ids = list({int(i) for i in ids if str(i).isdigit()})
+        if not ids:
+            return Response({'detail': 'ids is empty'}, status=status.HTTP_400_BAD_REQUEST)
+        if len(ids) > MAX_BULK:
+            return Response({'detail': f'Max {MAX_BULK} ids per request'}, status=status.HTTP_400_BAD_REQUEST)
+        qs = self.filter_queryset(self.get_queryset()).filter(id__in=ids)
+        with transaction.atomic():
+            deleted_ids = list(qs.values_list('id', flat=True))
+            qs.delete()
+        return Response({'deleted': len(deleted_ids), 'ids': deleted_ids})
+
+    @action(detail=False, methods=['patch'], url_path='bulk-update')
+    def bulk_update(self, request, *args, **kwargs):
+        serializer = BulkUpdateTaskSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        ids = data.pop('ids')
+        if len(ids) > MAX_BULK:
+            return Response({'detail': f'Max {MAX_BULK} ids per request'}, status=status.HTTP_400_BAD_REQUEST)
+        qs = self.filter_queryset(self.get_queryset()).filter(id__in=ids)
+        assignee = None
+        assignee_present = False
+        if 'assignee_id' in data:
+            assignee_present = True
+            assignee_id = data.pop('assignee_id')
+            if assignee_id is not None:
+                assignee = User.objects.filter(pk=assignee_id).first()
+                if assignee is None:
+                    return Response({'detail': 'assignee not found'}, status=status.HTTP_400_BAD_REQUEST)
+        project = None
+        project_present = False
+        if 'project_id' in data:
+            project_present = True
+            project_id = data.pop('project_id')
+            if project_id is not None:
+                project = Project.objects.filter(pk=project_id).first()
+                if project is None:
+                    return Response({'detail': 'project not found'}, status=status.HTTP_400_BAD_REQUEST)
+        with transaction.atomic():
+            updated_ids = []
+            for obj in qs.select_for_update():
+                for field, value in data.items():
+                    setattr(obj, field, value)
+                if assignee_present:
+                    obj.assignee = assignee
+                if project_present:
+                    obj.project = project
+                obj.save()
+                updated_ids.append(obj.id)
+        return Response({'updated': len(updated_ids), 'ids': updated_ids})
 
     @action(detail=False, methods=['get'])
     def calendar(self, request):

--- a/client/src/modules/crm/project-management/ProjectsList.vue
+++ b/client/src/modules/crm/project-management/ProjectsList.vue
@@ -69,10 +69,36 @@
       </div>
     </div>
 
-    <div v-else class="row g-4">
-      <div class="col-md-6 col-lg-4" v-for="project in projects" :key="project?.id">
-        <div class="project-card h-100 pm-fade-in" v-if="project">
-          <div class="project-header" :style="{ borderColor: project.color }">
+    <div v-else>
+      <div v-if="selectedItems.length" class="mb-3 d-flex align-items-center gap-2">
+        <div class="dropdown">
+          <button class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown">Массовые действия</button>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item" href="#" @click.prevent="confirmBulkDelete">Удалить</a></li>
+            <li class="dropend">
+              <a class="dropdown-item dropdown-toggle" href="#" data-bs-toggle="dropdown">Изменить статус</a>
+              <ul class="dropdown-menu">
+                <li v-for="status in projectStatuses" :key="status.code">
+                  <a class="dropdown-item" href="#" @click.prevent="bulkChangeStatus(status.code)">{{ status.name }}</a>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+        <button class="btn btn-outline-secondary" @click="clearSelection">Отменить выбор</button>
+        <div v-if="isBulkActionLoading" class="spinner-border spinner-border-sm text-primary" role="status"></div>
+      </div>
+      <div class="form-check mb-2">
+        <input class="form-check-input" type="checkbox" :checked="areAllSelected" @change="toggleSelectAll" id="selectAllProjects">
+        <label class="form-check-label" for="selectAllProjects">Выбрать все</label>
+      </div>
+      <div class="row g-4">
+        <div class="col-md-6 col-lg-4" v-for="project in projects" :key="project?.id">
+          <div class="project-card h-100 pm-fade-in position-relative" v-if="project">
+            <div class="form-check position-absolute top-0 start-0 m-2">
+              <input class="form-check-input" type="checkbox" v-model="selectedItems" :value="project.id" @click.stop>
+            </div>
+            <div class="project-header" :style="{ borderColor: project.color }">
             <div class="d-flex justify-content-between align-items-start mb-2">
               <span class="badge rounded-pill" :class="getStatusClass(project.status)">
                 {{ getStatusText(project.status) }}
@@ -339,7 +365,9 @@ export default {
       projectPriorities: [],
       loadingStatuses: false,
       organizations: [],
-      loadingOrganizations: false
+      loadingOrganizations: false,
+      selectedItems: [],
+      isBulkActionLoading: false
     }
   },
   
@@ -357,10 +385,54 @@ export default {
           this.loadProjects()
         }, 500)
       }
+    },
+    areAllSelected() {
+      return this.projects.length > 0 && this.selectedItems.length === this.projects.length
     }
   },
   
   methods: {
+    toggleSelectAll(event) {
+      if (event.target.checked) {
+        this.selectedItems = this.projects.map(p => p.id)
+      } else {
+        this.selectedItems = []
+      }
+    },
+    clearSelection() {
+      this.selectedItems = []
+    },
+    async confirmBulkDelete() {
+      if (!this.selectedItems.length) return
+      if (!confirm('Удалить выбранные проекты?')) return
+      this.isBulkActionLoading = true
+      try {
+        await projectManagementApi.bulkDeleteProjects(this.selectedItems)
+        this.showSuccess('Проекты удалены')
+        await this.loadProjects()
+        this.clearSelection()
+      } catch (error) {
+        console.error('Ошибка массового удаления проектов:', error)
+        this.showError('Не удалось удалить проекты')
+      } finally {
+        this.isBulkActionLoading = false
+      }
+    },
+    async bulkChangeStatus(status) {
+      if (!this.selectedItems.length) return
+      this.isBulkActionLoading = true
+      try {
+        await projectManagementApi.bulkUpdateProjects({ ids: this.selectedItems, status })
+        this.showSuccess('Статус проектов обновлен')
+        await this.loadProjects()
+        this.clearSelection()
+      } catch (error) {
+        console.error('Ошибка массового обновления проектов:', error)
+        this.showError('Не удалось обновить проекты')
+      } finally {
+        this.isBulkActionLoading = false
+      }
+    },
     async loadProjects() {
       this.loading = true
       try {
@@ -391,6 +463,7 @@ export default {
         } else {
           this.projects = Array.isArray(response.data) ? response.data : []
         }
+        this.selectedItems = []
       } catch (error) {
         console.error('Ошибка загрузки проектов:', error)
         this.projects = []

--- a/client/src/modules/crm/project-management/TasksList.vue
+++ b/client/src/modules/crm/project-management/TasksList.vue
@@ -102,12 +102,33 @@
     </div>
 
     <div v-else>
+      <div v-if="selectedItems.length" class="mb-3 d-flex align-items-center gap-2">
+        <div class="dropdown">
+          <button class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown">
+            Массовые действия
+          </button>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item" href="#" @click.prevent="confirmBulkDelete">Удалить</a></li>
+            <li class="dropend">
+              <a class="dropdown-item dropdown-toggle" href="#" data-bs-toggle="dropdown">Изменить статус</a>
+              <ul class="dropdown-menu">
+                <li v-for="status in taskStatuses" :key="status.code">
+                  <a class="dropdown-item" href="#" @click.prevent="bulkChangeStatus(status.code)">{{ status.name }}</a>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+        <button class="btn btn-outline-secondary" @click="clearSelection">Отменить выбор</button>
+        <div v-if="isBulkActionLoading" class="spinner-border spinner-border-sm text-primary" role="status"></div>
+      </div>
       <!-- Табличный вид -->
       <div class="tasks-table-wrapper">
         <div class="table-responsive">
           <table class="table table-hover tasks-table mb-0">
             <thead>
               <tr>
+                <th><input class="form-check-input" type="checkbox" :checked="areAllSelected" @change="toggleSelectAll" /></th>
                 <th>Задача</th>
                 <th>Проект</th>
                 <th>Исполнитель</th>
@@ -119,6 +140,7 @@
             </thead>
             <tbody>
               <tr v-for="task in tasks" :key="task?.id" class="task-row" @click="viewTask(task)">
+                <td @click.stop><input class="form-check-input" type="checkbox" v-model="selectedItems" :value="task.id" /></td>
                 <td class="task-cell-main">
                   <div class="task-info">
                     <h6 class="task-title mb-1">{{ task.title || 'Без названия' }}</h6>
@@ -564,7 +586,9 @@ export default {
       taskStatuses: [],
       taskPriorities: [],
       loadingStatuses: false,
-      loadingUsers: false
+      loadingUsers: false,
+      selectedItems: [],
+      isBulkActionLoading: false
     }
   },
   
@@ -590,6 +614,9 @@ export default {
           this.loadTasks()
         }, 500)
       }
+    },
+    areAllSelected() {
+      return this.tasks.length > 0 && this.selectedItems.length === this.tasks.length
     }
   },
 
@@ -610,6 +637,47 @@ export default {
   },
 
   methods: {
+    toggleSelectAll(event) {
+      if (event.target.checked) {
+        this.selectedItems = this.tasks.map(t => t.id)
+      } else {
+        this.selectedItems = []
+      }
+    },
+    clearSelection() {
+      this.selectedItems = []
+    },
+    async confirmBulkDelete() {
+      if (!this.selectedItems.length) return
+      if (!confirm('Удалить выбранные задачи?')) return
+      this.isBulkActionLoading = true
+      try {
+        await projectManagementApi.bulkDeleteTasks(this.selectedItems)
+        this.showSuccess('Задачи удалены')
+        await this.loadTasks()
+        this.clearSelection()
+      } catch (error) {
+        console.error('Ошибка массового удаления задач:', error)
+        this.showError('Не удалось удалить задачи')
+      } finally {
+        this.isBulkActionLoading = false
+      }
+    },
+    async bulkChangeStatus(status) {
+      if (!this.selectedItems.length) return
+      this.isBulkActionLoading = true
+      try {
+        await projectManagementApi.bulkUpdateTasks({ ids: this.selectedItems, status })
+        this.showSuccess('Статус задач обновлен')
+        await this.loadTasks()
+        this.clearSelection()
+      } catch (error) {
+        console.error('Ошибка массового обновления задач:', error)
+        this.showError('Не удалось обновить задачи')
+      } finally {
+        this.isBulkActionLoading = false
+      }
+    },
     async loadProjects() {
       try {
         const response = await projectManagementApi.getProjects({ my_projects: true })
@@ -689,6 +757,7 @@ export default {
         } else {
           this.tasks = Array.isArray(response.data) ? response.data : []
         }
+        this.selectedItems = []
       } catch (error) {
         console.error('Ошибка загрузки задач:', error)
         this.tasks = []

--- a/client/src/modules/crm/project-management/js/projectManagementApi.js
+++ b/client/src/modules/crm/project-management/js/projectManagementApi.js
@@ -54,6 +54,14 @@ class ProjectManagementApi {
         return await this.client.delete(`/crm/projects/${id}/`);
     }
 
+    async bulkDeleteProjects(ids) {
+        return await this.client.delete('/crm/projects/bulk-delete/', { data: { ids } });
+    }
+
+    async bulkUpdateProjects(data) {
+        return await this.client.patch('/crm/projects/bulk-update/', data);
+    }
+
     async getProjectTasks(projectId, params = {}) {
         return await this.client.get(`/crm/projects/${projectId}/tasks/`, { params });
     }
@@ -91,6 +99,14 @@ class ProjectManagementApi {
 
     async deleteTask(id) {
         return await this.client.delete(`/crm/tasks/${id}/`);
+    }
+
+    async bulkDeleteTasks(ids) {
+        return await this.client.delete('/crm/tasks/bulk-delete/', { data: { ids } });
+    }
+
+    async bulkUpdateTasks(data) {
+        return await this.client.patch('/crm/tasks/bulk-update/', data);
     }
 
     async changeTaskStatus(taskId, status) {


### PR DESCRIPTION
## Summary
- add bulk delete/update endpoints for CRM projects and tasks
- enable selecting multiple items and triggering bulk actions in project and task lists
- provide client API helpers and tests for new bulk actions

## Testing
- `API_SECRET_KEY=test poetry run python src/manage.py test src.modules.crm -v 2` *(fails: SystemCheckError: Competency.blooms_level requires max_length)*

------
https://chatgpt.com/codex/tasks/task_e_6899089126a083298014a0dafcdb3df7