### PR TITLE
feat(lms): add stats dashboards

### DIFF
--- a/api/src/modules/lms/analytics.py
+++ b/api/src/modules/lms/analytics.py
@@ -1,11 +1,246 @@
-from django.db import models
+from datetime import date, timedelta
+from typing import Optional, Dict, Any, List
+
 from django.contrib.auth.models import User
-from typing import Dict, Any
+from django.db import models
+from django.db.models import Count, Avg, Q, F
+from django.utils import timezone
 
 from .models import (
-    Subject, Enrollment, Grade, Test, TestAttempt, Assignment,
-    SubmittedAssignment, Forum, ForumPost, UserBadge
+    Subject,
+    Enrollment,
+    Grade,
+    Test,
+    TestAttempt,
+    Assignment,
+    SubmittedAssignment,
+    Forum,
+    ForumPost,
+    UserBadge,
+    Badge,
 )
+
+
+def _parse_date(param: Optional[str], default: date) -> date:
+    """Безопасное преобразование строки в дату."""
+    if param:
+        try:
+            return date.fromisoformat(param)
+        except ValueError:
+            pass
+    return default
+
+
+def get_student_dashboard(
+    user: User,
+    date_from: Optional[str],
+    date_to: Optional[str],
+    course_id: Optional[int],
+) -> Dict[str, Any]:
+    today = timezone.now().date()
+    end = _parse_date(date_to, today)
+    start = _parse_date(date_from, end - timedelta(days=30))
+
+    enrollments = Enrollment.objects.filter(student=user)
+    if course_id:
+        enrollments = enrollments.filter(subject_id=course_id)
+
+    in_progress = enrollments.filter(status='active').count()
+    completed = enrollments.filter(status='completed').count()
+
+    grades_qs = Grade.objects.filter(student=user, lastupdate__date__range=(start, end))
+    if course_id:
+        grades_qs = grades_qs.filter(subject_id=course_id)
+    gpa = grades_qs.aggregate(avg=Avg('grade'))['avg']
+
+    # просроченные задания
+    assignments = Assignment.objects.filter(
+        Q(subject__enrollment__student=user)
+    )
+    if course_id:
+        assignments = assignments.filter(subject_id=course_id)
+
+    overdue_tasks = assignments.filter(
+        deadline__lt=today
+    ).exclude(
+        submittedassignment__student=user
+    ).count()
+
+    # streak - здесь нет данных, возвращаем 0
+    streak_days = 0
+
+    summary = {
+        "in_progress": in_progress,
+        "completed": completed,
+        "gpa": gpa if gpa is not None else None,
+        "overdue_tasks": overdue_tasks,
+        "streak_days": streak_days,
+    }
+
+    grade_trend = [
+        {
+            "date": rec["lastupdate__date"].isoformat(),
+            "avg_grade": rec["avg"],
+        }
+        for rec in grades_qs.values("lastupdate__date")
+        .annotate(avg=Avg("grade"))
+        .order_by("lastupdate__date")
+    ]
+
+    upcoming_deadlines_qs = assignments.filter(deadline__gte=today).order_by("deadline")
+    upcoming_deadlines = []
+    for ass in upcoming_deadlines_qs[:10]:
+        status = "ok"
+        if ass.deadline < today:
+            status = "overdue"
+        elif ass.deadline <= today + timedelta(days=2):
+            status = "risk"
+        upcoming_deadlines.append(
+            {
+                "id": ass.id,
+                "title": ass.title,
+                "course": {
+                    "id": ass.subject.id if ass.subject else None,
+                    "name": ass.subject.name if ass.subject else "",
+                },
+                "due": ass.deadline.isoformat() if ass.deadline else None,
+                "status": status,
+            }
+        )
+
+    # прогресс достижений
+    achievements_progress = get_achievements_progress(user.id)
+
+    # рекомендации – пока пусто
+    recommendations: List[Dict[str, Any]] = []
+
+    return {
+        "summary": summary,
+        "grade_trend": grade_trend,
+        "upcoming_deadlines": upcoming_deadlines,
+        "achievements_progress": achievements_progress,
+        "recommendations": recommendations,
+    }
+
+
+def get_teacher_dashboard(
+    user: User,
+    date_from: Optional[str],
+    date_to: Optional[str],
+    course_id: Optional[int],
+) -> Dict[str, Any]:
+    today = timezone.now().date()
+    end = _parse_date(date_to, today)
+    start = _parse_date(date_from, end - timedelta(days=30))
+
+    courses = Subject.objects.all()
+    if not user.is_staff:
+        courses = courses.filter(teacher=user)
+    if course_id:
+        courses = courses.filter(id=course_id)
+
+    enrollments = Enrollment.objects.filter(subject__in=courses)
+    total_enrolled = enrollments.count()
+    completed = enrollments.filter(status='completed').count()
+
+    completion_rate = (completed / total_enrolled * 100) if total_enrolled else 0
+
+    grades_qs = Grade.objects.filter(subject__in=courses, lastupdate__date__range=(start, end))
+    avg_grade = grades_qs.aggregate(avg=Avg('grade'))['avg']
+
+    pending_reviews = SubmittedAssignment.objects.filter(
+        assignment__subject__in=courses, grade=0
+    ).count()
+
+    summary = {
+        "active_courses": courses.count(),
+        "enrolled": total_enrolled,
+        "completion_rate": completion_rate,
+        "on_time_rate": 0.0,
+        "avg_grade": avg_grade if avg_grade is not None else None,
+        "pending_reviews": pending_reviews,
+    }
+
+    course_stats: List[Dict[str, Any]] = []
+    for course in courses:
+        course_enrollments = enrollments.filter(subject=course)
+        c_total = course_enrollments.count()
+        c_completed = course_enrollments.filter(status='completed').count()
+        c_completion_rate = (c_completed / c_total * 100) if c_total else 0
+        c_avg_grade = grades_qs.filter(subject=course).aggregate(avg=Avg('grade'))['avg']
+        overdues = Assignment.objects.filter(subject=course, deadline__lt=today).count()
+        course_stats.append(
+            {
+                "id": course.id,
+                "name": course.name,
+                "enrolled": c_total,
+                "completion_rate": c_completion_rate,
+                "avg_grade": c_avg_grade if c_avg_grade is not None else None,
+                "on_time_rate": 0.0,
+                "overdues": overdues,
+            }
+        )
+
+    distribution = {"A": 0, "B": 0, "C": 0, "D": 0, "F": 0}
+    for value in grades_qs.values_list("grade", flat=True):
+        if value >= 90:
+            distribution["A"] += 1
+        elif value >= 75:
+            distribution["B"] += 1
+        elif value >= 60:
+            distribution["C"] += 1
+        elif value >= 50:
+            distribution["D"] += 1
+        else:
+            distribution["F"] += 1
+
+    at_risk_students: List[Dict[str, Any]] = []
+    for enr in enrollments.select_related('student', 'subject'):
+        overdue = Assignment.objects.filter(
+            subject=enr.subject,
+            deadline__lt=today
+        ).exclude(
+            submittedassignment__student=enr.student
+        ).count()
+        if overdue:
+            last_grade = Grade.objects.filter(student=enr.student).order_by('-lastupdate').values_list('lastupdate', flat=True).first()
+            at_risk_students.append(
+                {
+                    "user_id": enr.student.id,
+                    "full_name": enr.student.get_full_name() or enr.student.username,
+                    "course": {"id": enr.subject.id, "name": enr.subject.name},
+                    "overdues": overdue,
+                    "last_activity": last_grade.isoformat() if last_grade else None,
+                }
+            )
+
+    return {
+        "summary": summary,
+        "courses": course_stats,
+        "grade_distribution": distribution,
+        "at_risk_students": at_risk_students,
+    }
+
+
+def get_achievements_progress(user_id: int) -> List[Dict[str, Any]]:
+    user_badges = set(
+        UserBadge.objects.filter(user_id=user_id).values_list("badge_id", flat=True)
+    )
+    result: List[Dict[str, Any]] = []
+    for badge in Badge.objects.filter(is_active=True):
+        unlocked = badge.id in user_badges
+        result.append(
+            {
+                "badge_id": badge.id,
+                "title": badge.name,
+                "category": badge.badge_type,
+                "progress": 100 if unlocked else 0,
+                "next_threshold": 0 if unlocked else 1,
+                "icon": badge.image.url if badge.image else "",
+                "unlocked": unlocked,
+            }
+        )
+    return result
 
 class AnalyticsService:
     """Сервис для аналитики и статистики"""

--- a/api/src/modules/lms/urls.py
+++ b/api/src/modules/lms/urls.py
@@ -50,6 +50,7 @@ urlpatterns = [
     path('analytics/student/', AnalyticsViewSet.as_view({'get': 'student_stats'}), name='student-analytics'),
     path('analytics/teacher/', AnalyticsViewSet.as_view({'get': 'teacher_stats'}), name='teacher-analytics'),
     path('analytics/dashboard/', AnalyticsViewSet.as_view({'get': 'dashboard'}), name='dashboard'),
+    path('analytics/achievements/progress/', AnalyticsViewSet.as_view({'get': 'achievements_progress'}), name='achievements-progress'),
     path('analytics/debug-lessons/', AnalyticsViewSet.as_view({'get': 'debug_lessons'}), name='debug-lessons'),
     
     # Endpoints для профиля

--- a/api/src/modules/lms/views.py
+++ b/api/src/modules/lms/views.py
@@ -17,6 +17,7 @@ from .base_views import (
 )
 from .utils import get_user_accessible_subjects, get_upcoming_deadlines
 from .analytics import AnalyticsService
+from . import analytics
 from .models import (
     Student, Teacher, StudentGroup, Subject, Grade, Theme,
     Lesson, Test, TestAttempt, SubmittedAssignment, UserRole,
@@ -1351,32 +1352,29 @@ class AnalyticsViewSet(viewsets.ViewSet):
         serializer = TeacherStatsSerializer(stats)
         return Response(serializer.data)
     
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=['get'], url_path='dashboard')
     def dashboard(self, request):
-        """Общая информация для дашборда"""
-        user = request.user
-        
-        # Используем утилиту для получения дедлайнов
-        deadlines = get_upcoming_deadlines(user)
-        
-        # Непрочитанные уведомления
-        unread_notifications = Notification.objects.filter(
-            recipient=user, is_read=False
-        ).count()
-        
-        # Последние оценки
-        recent_grades = Grade.objects.filter(
-            student=user
-        ).order_by('-lastupdate')[:5]
-        
-        dashboard_data = {
-            'upcoming_assignments': AssignmentSerializer(deadlines['assignments'], many=True).data,
-            'upcoming_events': CalendarEventSerializer(deadlines['events'], many=True).data,
-            'unread_notifications': unread_notifications,
-            'recent_grades': GradeSerializer(recent_grades, many=True).data
-        }
-        
-        return Response(dashboard_data)
+        role = request.query_params.get('role')
+        date_from = request.query_params.get('from')
+        date_to = request.query_params.get('to')
+        course_id = request.query_params.get('course')
+
+        is_teacher = bool(request.user.is_staff or getattr(request.user, 'is_teacher', False))
+
+        if role == 'teacher' and is_teacher:
+            data = analytics.get_teacher_dashboard(request.user, date_from, date_to, course_id)
+        else:
+            data = analytics.get_student_dashboard(request.user, date_from, date_to, course_id)
+
+        return Response(data)
+
+    @action(detail=False, methods=['get'], url_path='achievements/progress')
+    def achievements_progress(self, request):
+        user_id = int(request.query_params.get('user') or request.user.id)
+        if user_id != request.user.id and not (request.user.is_staff or getattr(request.user, 'is_teacher', False)):
+            return Response({"detail": "Forbidden"}, status=403)
+        data = analytics.get_achievements_progress(user_id)
+        return Response(data)
 
     @action(detail=False, methods=['get'])
     def debug_lessons(self, request):

--- a/client/src/config/routes-config.json
+++ b/client/src/config/routes-config.json
@@ -644,6 +644,14 @@
         "requiresAuth": true
       }
     },
+    "LMSStats": {
+      "path": "/lms/stats",
+      "component": "@/modules/lms/Stats/LmsStatsView.vue",
+      "meta": {
+        "title": "Статистика",
+        "requiresAuth": true
+      }
+    },
     "LMSLessonsManagement": {
       "path": "/lms/lessons-management",
       "component": "@/modules/lms/LessonsManagement/LessonsManagementView.vue",

--- a/client/src/js/api/endpoints.js
+++ b/client/src/js/api/endpoints.js
@@ -163,6 +163,9 @@ export const endpoints = {
         delete: id => `settings/tags/${id}/`
     },
     lms: {
+        base: '/lms',
+        analyticsDashboard: '/lms/analytics/dashboard/',
+        achievementsProgress: '/lms/analytics/achievements/progress/',
         // Пользователи и профили
         profiles: 'lms/profiles/',
         myProfile: 'lms/profile/me/',

--- a/client/src/modules/lms/Stats/LmsStatsView.vue
+++ b/client/src/modules/lms/Stats/LmsStatsView.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="container-fluid py-3">
+    <div class="row mb-3 g-2 align-items-end">
+      <div class="col-md-3">
+        <label class="form-label">От</label>
+        <input type="date" v-model="filters.from" class="form-control" />
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">До</label>
+        <input type="date" v-model="filters.to" class="form-control" />
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Курс</label>
+        <select v-model="filters.course" class="form-select">
+          <option value="">Все</option>
+          <option v-for="c in courses" :key="c.id" :value="c.id">{{ c.name }}</option>
+        </select>
+      </div>
+    </div>
+
+    <StatsSummary v-if="data" :summary="data.summary" :role="role" class="mb-4" />
+
+    <div v-if="role === 'student' && data">
+      <div class="row">
+        <div class="col-lg-8">
+          <GradeTrendChart :data="data.grade_trend" />
+        </div>
+        <div class="col-lg-4">
+          <DeadlinesList :deadlines="data.upcoming_deadlines" />
+        </div>
+      </div>
+      <AchievementsProgress class="mt-3" :achievements="data.achievements_progress" />
+      <Recommendations class="mt-3" :items="data.recommendations" />
+    </div>
+
+    <div v-else-if="role === 'teacher' && data">
+      <CoursesTable :courses="data.courses" class="mb-3" />
+      <div class="row">
+        <div class="col-lg-6">
+          <GradeDistributionChart :distribution="data.grade_distribution" />
+        </div>
+        <div class="col-lg-6">
+          <AtRiskList :students="data.at_risk_students" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, watch } from 'vue'
+import { lmsApi } from '../js/lmsApi'
+import { useUserRole } from '../composables/useUserRole'
+import StatsSummary from './components/StatsSummary.vue'
+import GradeTrendChart from './components/GradeTrendChart.vue'
+import DeadlinesList from './components/DeadlinesList.vue'
+import AchievementsProgress from './components/AchievementsProgress.vue'
+import CoursesTable from './components/CoursesTable.vue'
+import GradeDistributionChart from './components/GradeDistributionChart.vue'
+import AtRiskList from './components/AtRiskList.vue'
+import Recommendations from './components/Recommendations.vue'
+
+const userRole = useUserRole()
+const role = computed(() => (userRole.isTeacher.value || userRole.isAdmin.value) ? 'teacher' : 'student')
+
+const filters = ref({ from: '', to: '', course: '' })
+const courses = ref([])
+const data = ref(null)
+
+async function loadCourses() {
+  const res = await lmsApi.getCourses()
+  courses.value = res.data.results || res.data || []
+}
+
+async function loadData() {
+  const params = { role: role.value }
+  if (filters.value.from) params.from = filters.value.from
+  if (filters.value.to) params.to = filters.value.to
+  if (filters.value.course) params.course = filters.value.course
+  const res = await lmsApi.get('/analytics/dashboard/', params)
+  data.value = res.data
+}
+
+onMounted(async () => {
+  await loadCourses()
+  await loadData()
+})
+
+watch(filters, loadData, { deep: true })
+</script>

--- a/client/src/modules/lms/Stats/components/AchievementsProgress.vue
+++ b/client/src/modules/lms/Stats/components/AchievementsProgress.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="row g-3">
+    <div v-for="a in achievements" :key="a.badge_id" class="col-12 col-md-6 col-lg-4">
+      <Card>
+        <div class="d-flex align-items-center mb-2">
+          <img v-if="a.icon" :src="a.icon" class="me-2" style="width:24px;height:24px" />
+          <strong>{{ a.title }}</strong>
+          <span class="badge bg-secondary ms-auto">{{ a.category }}</span>
+        </div>
+        <div class="progress mb-1">
+          <div class="progress-bar" role="progressbar" :style="{ width: `${a.progress}%` }"></div>
+        </div>
+        <small v-if="!a.unlocked" class="text-muted">Осталось {{ a.next_threshold - a.progress }}</small>
+        <small v-else class="text-success">Получено</small>
+      </Card>
+    </div>
+    <div v-if="!achievements.length" class="col-12">
+      <Card><p class="text-muted mb-0">Нет данных</p></Card>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import Card from '../shared/Card.vue'
+const props = defineProps({ achievements: { type: Array, default: () => [] } })
+</script>

--- a/client/src/modules/lms/Stats/components/AtRiskList.vue
+++ b/client/src/modules/lms/Stats/components/AtRiskList.vue
@@ -1,0 +1,30 @@
+<template>
+  <Card>
+    <h5 class="mb-3">Студенты в зоне риска</h5>
+    <ul class="list-group list-group-flush">
+      <li v-for="s in students" :key="s.user_id" class="list-group-item">
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
+            <div>{{ s.full_name }}</div>
+            <small class="text-muted">{{ s.course.name }}</small>
+          </div>
+          <div class="text-end">
+            <span class="badge bg-danger me-2">{{ s.overdues }}</span>
+            <small class="text-muted">{{ formatDate(s.last_activity) }}</small>
+          </div>
+        </div>
+      </li>
+      <li v-if="!students.length" class="list-group-item text-muted">Нет данных</li>
+    </ul>
+  </Card>
+</template>
+
+<script setup>
+import Card from '../shared/Card.vue'
+import { format } from 'date-fns'
+const props = defineProps({ students: { type: Array, default: () => [] } })
+function formatDate(d) {
+  if (!d) return ''
+  return format(new Date(d), 'dd.MM.yyyy')
+}
+</script>

--- a/client/src/modules/lms/Stats/components/CoursesTable.vue
+++ b/client/src/modules/lms/Stats/components/CoursesTable.vue
@@ -1,0 +1,37 @@
+<template>
+  <Card>
+    <h5 class="mb-3">Курсы</h5>
+    <div class="table-responsive">
+      <table class="table table-sm">
+        <thead>
+          <tr>
+            <th>Курс</th>
+            <th>Записано</th>
+            <th>Завершённость %</th>
+            <th>Ср. балл</th>
+            <th>В срок %</th>
+            <th>Просрочки</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="c in courses" :key="c.id">
+            <td>{{ c.name }}</td>
+            <td><span class="badge bg-primary">{{ c.enrolled }}</span></td>
+            <td>{{ Number(c.completion_rate).toFixed(1) }}</td>
+            <td>{{ c.avg_grade ?? '-' }}</td>
+            <td>{{ Number(c.on_time_rate).toFixed(1) }}</td>
+            <td><span class="badge bg-danger">{{ c.overdues }}</span></td>
+          </tr>
+          <tr v-if="!courses.length">
+            <td colspan="6" class="text-muted">Нет данных</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </Card>
+</template>
+
+<script setup>
+import Card from '../shared/Card.vue'
+const props = defineProps({ courses: { type: Array, default: () => [] } })
+</script>

--- a/client/src/modules/lms/Stats/components/DeadlinesList.vue
+++ b/client/src/modules/lms/Stats/components/DeadlinesList.vue
@@ -1,0 +1,35 @@
+<template>
+  <Card>
+    <h5 class="mb-3">Ближайшие дедлайны</h5>
+    <ul class="list-group list-group-flush">
+      <li v-for="d in deadlines" :key="d.id" class="list-group-item d-flex justify-content-between align-items-center">
+        <div>
+          <div>{{ d.title }}</div>
+          <small class="text-muted">{{ d.course.name }}</small>
+        </div>
+        <span :class="statusClass(d.status)">{{ formatDate(d.due) }}</span>
+      </li>
+      <li v-if="!deadlines.length" class="list-group-item text-muted">Нет данных</li>
+    </ul>
+  </Card>
+</template>
+
+<script setup>
+import Card from '../shared/Card.vue'
+import { format } from 'date-fns'
+
+const props = defineProps({ deadlines: { type: Array, default: () => [] } })
+
+function statusClass(status) {
+  return {
+    'badge bg-danger': status === 'overdue',
+    'badge bg-warning text-dark': status === 'risk',
+    'badge bg-secondary': status === 'ok'
+  }
+}
+
+function formatDate(dateStr) {
+  if (!dateStr) return ''
+  return format(new Date(dateStr), 'dd.MM.yyyy')
+}
+</script>

--- a/client/src/modules/lms/Stats/components/GradeDistributionChart.vue
+++ b/client/src/modules/lms/Stats/components/GradeDistributionChart.vue
@@ -1,0 +1,24 @@
+<template>
+  <Card>
+    <h5 class="mb-3">Распределение оценок</h5>
+    <div class="d-flex align-items-end" style="height:150px;">
+      <div v-for="(count,label) in distribution" :key="label" class="flex-fill text-center">
+        <div class="bg-primary mx-1" :style="{height: maxValue ? (count/maxValue*100)+'%' : '0%'}"></div>
+        <small>{{ label }}</small>
+      </div>
+    </div>
+  </Card>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import Card from '../shared/Card.vue'
+const props = defineProps({ distribution: { type: Object, default: () => ({}) } })
+const maxValue = computed(() => Math.max(...Object.values(props.distribution || {}), 0))
+</script>
+
+<style scoped>
+.bg-primary {
+  width: 100%;
+}
+</style>

--- a/client/src/modules/lms/Stats/components/GradeTrendChart.vue
+++ b/client/src/modules/lms/Stats/components/GradeTrendChart.vue
@@ -1,0 +1,39 @@
+<template>
+  <Card>
+    <h5 class="mb-3">Тренд оценок</h5>
+    <canvas v-if="data.length" ref="canvas" height="120"></canvas>
+    <p v-else class="text-muted mb-0">Нет данных</p>
+  </Card>
+</template>
+
+<script setup>
+import { onMounted, ref, watch } from 'vue'
+import { Chart } from 'chart.js/auto'
+import Card from '../shared/Card.vue'
+
+const props = defineProps({ data: { type: Array, default: () => [] } })
+const canvas = ref(null)
+let chart
+
+function render() {
+  if (!canvas.value) return
+  if (chart) chart.destroy()
+  const labels = props.data.map(d => d.date)
+  const values = props.data.map(d => d.avg_grade)
+  chart = new Chart(canvas.value, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [{ label: 'Средний балл', data: values, fill: false, tension: 0.3 }]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: true, max: 100 }
+      }
+    }
+  })
+}
+
+onMounted(render)
+watch(() => props.data, render)
+</script>

--- a/client/src/modules/lms/Stats/components/Recommendations.vue
+++ b/client/src/modules/lms/Stats/components/Recommendations.vue
@@ -1,0 +1,16 @@
+<template>
+  <Card v-if="items.length">
+    <h5 class="mb-3">Рекомендации</h5>
+    <ul class="list-group list-group-flush">
+      <li v-for="r in items" :key="r.course_id" class="list-group-item">
+        <div class="fw-bold">{{ r.title }}</div>
+        <small class="text-muted">{{ r.reason }}</small>
+      </li>
+    </ul>
+  </Card>
+</template>
+
+<script setup>
+import Card from '../shared/Card.vue'
+const props = defineProps({ items: { type: Array, default: () => [] } })
+</script>

--- a/client/src/modules/lms/Stats/components/StatsSummary.vue
+++ b/client/src/modules/lms/Stats/components/StatsSummary.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="row g-3">
+    <div v-for="card in cards" :key="card.label" class="col-12 col-md-4 col-lg-2">
+      <div class="card text-center h-100">
+        <div class="card-body">
+          <div class="h5 mb-1">{{ card.value }}</div>
+          <div class="text-muted small">{{ card.label }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  summary: { type: Object, default: () => ({}) },
+  role: { type: String, default: 'student' }
+})
+
+const cards = computed(() => {
+  if (props.role === 'teacher') {
+    return [
+      { label: 'Активных курсов', value: props.summary?.active_courses || 0 },
+      { label: 'Записано', value: props.summary?.enrolled || 0 },
+      { label: 'Завершённость %', value: props.summary?.completion_rate || 0 },
+      { label: 'В срок %', value: props.summary?.on_time_rate || 0 },
+      { label: 'Средний балл', value: props.summary?.avg_grade ?? '-' },
+      { label: 'На проверке', value: props.summary?.pending_reviews || 0 }
+    ]
+  }
+  return [
+    { label: 'Курсов в прогрессе', value: props.summary?.in_progress || 0 },
+    { label: 'Завершено', value: props.summary?.completed || 0 },
+    { label: 'GPA', value: props.summary?.gpa ?? '-' },
+    { label: 'Просрочки', value: props.summary?.overdue_tasks || 0 },
+    { label: 'Стрик', value: props.summary?.streak_days || 0 }
+  ]
+})
+</script>
+
+<style scoped>
+.card {
+  min-height: 100%;
+}
+</style>

--- a/client/src/modules/lms/Stats/shared/Card.vue
+++ b/client/src/modules/lms/Stats/shared/Card.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="card mb-3">
+    <div class="card-body">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+.card {
+  height: 100%;
+}
+</style>

--- a/client/src/modules/lms/js/lmsApi.js
+++ b/client/src/modules/lms/js/lmsApi.js
@@ -2,6 +2,12 @@ import { apiClient } from '../../../js/api/manager'
 import { endpoints } from '../../../js/api/endpoints'
 
 export const lmsApi = {
+  async get(path, params = {}) {
+    const qs = new URLSearchParams(params).toString()
+    const url = `${endpoints.lms.base}${path}${qs ? `?${qs}` : ''}`
+    return apiClient.get(url)
+  },
+
   // Курсы
   async getCourses() {
     return await apiClient.get(endpoints.lms.subjects)


### PR DESCRIPTION
## Summary
- add student and teacher dashboard analytics with achievements progress endpoints
- expose dashboard and badge progress routes in API and router
- implement LMS statistics page with charts, deadlines and course tables

## Testing
- `poetry run python src/manage.py check` *(fails: Poetry could not find a pyproject.toml file)*
- `npm run lint` *(fails: 382 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68992990b8ac83299cdb29a73d0462ab