### PR TITLE
Implement organization roles and permission checks

### DIFF
--- a/api/src/modules/crm/migrations/0012_update_org_roles.py
+++ b/api/src/modules/crm/migrations/0012_update_org_roles.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+
+
+def forwards(apps, schema_editor):
+    OrganizationMember = apps.get_model('crm', 'OrganizationMember')
+    Organization = apps.get_model('crm', 'Organization')
+    OrganizationMember.objects.filter(role='viewer').update(role='observer')
+    Organization.objects.filter(default_role='viewer').update(default_role='observer')
+
+
+def backwards(apps, schema_editor):
+    OrganizationMember = apps.get_model('crm', 'OrganizationMember')
+    Organization = apps.get_model('crm', 'Organization')
+    OrganizationMember.objects.filter(role='observer').update(role='viewer')
+    Organization.objects.filter(default_role='observer').update(default_role='viewer')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('crm', '0011_update_organization_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='organization',
+            name='default_role',
+            field=models.CharField(max_length=16, choices=[('member', 'member'), ('admin', 'admin'), ('observer', 'observer')], default='member', verbose_name='Роль по умолчанию'),
+        ),
+        migrations.AlterField(
+            model_name='organizationmember',
+            name='role',
+            field=models.CharField(max_length=16, choices=[('owner', 'owner'), ('admin', 'admin'), ('member', 'member'), ('observer', 'observer')], default='member', verbose_name='Роль'),
+        ),
+        migrations.AlterField(
+            model_name='organizationinvite',
+            name='role',
+            field=models.CharField(max_length=20, choices=[('owner', 'owner'), ('admin', 'admin'), ('member', 'member'), ('observer', 'observer')], default='member', verbose_name='Роль'),
+        ),
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/api/src/modules/crm/models.py
+++ b/api/src/modules/crm/models.py
@@ -8,6 +8,13 @@ import secrets
 
 User = get_user_model()
 
+
+class OrgRole(models.TextChoices):
+    OWNER = 'owner', 'Owner'
+    ADMIN = 'admin', 'Admin'
+    MEMBER = 'member', 'Member'
+    OBSERVER = 'observer', 'Observer'
+
 class ProjectStatus(models.Model):
     """Статусы проектов"""
     name = models.CharField(max_length=100, verbose_name='Название статуса')
@@ -107,9 +114,9 @@ class Organization(models.Model):
         ('private', 'private'),
     ]
     ROLE_CHOICES = [
-        ('member', 'member'),
-        ('admin', 'admin'),
-        ('viewer', 'viewer'),
+        (OrgRole.MEMBER, 'member'),
+        (OrgRole.ADMIN, 'admin'),
+        (OrgRole.OBSERVER, 'observer'),
     ]
     STATUS_CHOICES = [
         ('active', 'active'),
@@ -133,7 +140,7 @@ class Organization(models.Model):
     owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name='owned_organizations', verbose_name='Владелец')
     members = models.ManyToManyField(User, through='OrganizationMember', related_name='organizations', through_fields=('organization', 'user'), verbose_name='Участники')
     visibility = models.CharField(max_length=20, choices=VISIBILITY_CHOICES, default='private', verbose_name='Видимость')
-    default_role = models.CharField(max_length=20, choices=ROLE_CHOICES, default='member', verbose_name='Роль по умолчанию')
+    default_role = models.CharField(max_length=16, choices=ROLE_CHOICES, default=OrgRole.MEMBER, verbose_name='Роль по умолчанию')
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='active', verbose_name='Статус')
     created_at = models.DateTimeField(auto_now_add=True, verbose_name='Дата создания')
     updated_at = models.DateTimeField(auto_now=True, verbose_name='Дата обновления')
@@ -161,12 +168,7 @@ class Organization(models.Model):
 class OrganizationMember(models.Model):
     """Участник организации"""
 
-    ROLE_CHOICES = [
-        ('owner', 'owner'),
-        ('admin', 'admin'),
-        ('member', 'member'),
-        ('viewer', 'viewer'),
-    ]
+    ROLE_CHOICES = OrgRole.choices
     STATUS_CHOICES = [
         ('pending', 'pending'),
         ('accepted', 'accepted'),
@@ -176,7 +178,7 @@ class OrganizationMember(models.Model):
 
     organization = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name='memberships')
     user = models.ForeignKey(settings.AUTH_USER_MODEL,on_delete=models.CASCADE,related_name='organization_memberships')
-    role = models.CharField(max_length=20, choices=ROLE_CHOICES, default='member', verbose_name='Роль')
+    role = models.CharField(max_length=16, choices=ROLE_CHOICES, default=OrgRole.MEMBER, verbose_name='Роль')
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='pending', verbose_name='Статус')
     invited_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -196,6 +198,18 @@ class OrganizationMember(models.Model):
 
     def __str__(self):
         return f"{self.user.get_full_name()} - {self.organization.name}"
+
+    def can_view(self) -> bool:
+        return True
+
+    def can_be_assigned(self) -> bool:
+        return self.role in {OrgRole.MEMBER, OrgRole.ADMIN, OrgRole.OWNER}
+
+    def can_manage_org(self) -> bool:
+        return self.role in {OrgRole.ADMIN, OrgRole.OWNER}
+
+    def is_owner(self) -> bool:
+        return self.role == OrgRole.OWNER
 class OrganizationInvite(models.Model):
     """Приглашение в организацию"""
 

--- a/api/src/modules/crm/permissions.py
+++ b/api/src/modules/crm/permissions.py
@@ -1,0 +1,45 @@
+from rest_framework.permissions import BasePermission
+from .models import Organization, OrganizationMember, OrgRole
+
+
+def _get_membership(user, org: Organization):
+    if not user or not user.is_authenticated:
+        return None
+    return OrganizationMember.objects.filter(user=user, organization=org).first()
+
+
+class IsOrgObserverOrAbove(BasePermission):
+    """Просмотр (observer+)"""
+
+    def has_object_permission(self, request, view, obj):
+        org = getattr(obj, 'organization', None) or getattr(
+            getattr(obj, 'project', None), 'organization', None
+        )
+        if not org:
+            return False
+        m = _get_membership(request.user, org)
+        return bool(m)
+
+
+class IsOrgMemberOrAbove(BasePermission):
+    """Действия, требующие членства"""
+
+    def has_object_permission(self, request, view, obj):
+        org = getattr(obj, 'organization', None) or getattr(
+            getattr(obj, 'project', None), 'organization', None
+        )
+        if not org:
+            return False
+        m = _get_membership(request.user, org)
+        return bool(m and m.role in {OrgRole.MEMBER, OrgRole.ADMIN, OrgRole.OWNER})
+
+
+class IsOrgAdminOrOwner(BasePermission):
+    """Приглашения, изменение ролей, редактирование организации"""
+
+    def has_object_permission(self, request, view, obj):
+        org = obj if hasattr(obj, 'memberships') else getattr(obj, 'organization', None)
+        if not org:
+            return False
+        m = _get_membership(request.user, org)
+        return bool(m and m.role in {OrgRole.ADMIN, OrgRole.OWNER})

--- a/api/src/modules/crm/serializers.py
+++ b/api/src/modules/crm/serializers.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 from .models import (
     Project, ProjectMember, Task, TaskComment, TaskAttachment, TimeLog,
     ProjectStatus, ProjectPriority, TaskStatus, TaskPriority,
-    Organization, OrganizationMember, OrganizationInvite
+    Organization, OrganizationMember, OrganizationInvite, OrgRole
 )
 
 User = get_user_model()
@@ -126,11 +126,11 @@ class OrganizationSerializer(serializers.ModelSerializer):
         # если прилетел "owner" — тихо переводим в member
         if value == 'owner':
             return 'member'
-        allowed = {'member', 'admin', 'viewer'}
+        allowed = {'member', 'admin', 'observer'}
         if value not in allowed:
             # можно тоже схлопнуть в member, но оставлю явную ошибку:
             raise serializers.ValidationError(
-                'Недопустимое значение. Разрешено: member, admin, viewer.'
+                'Недопустимое значение. Разрешено: member, admin, observer.'
             )
         return value
 
@@ -477,6 +477,20 @@ class TaskSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     "Дата окончания не может быть раньше даты начала"
                 )
+        project = data.get('project') or getattr(self.instance, 'project', None)
+        assignee_id = data.get('assignee_id') or (
+            getattr(self.instance, 'assignee_id', None) if self.instance else None
+        )
+        if project and assignee_id:
+            org = project.organization
+            if org:
+                m = OrganizationMember.objects.filter(
+                    organization=org, user_id=assignee_id
+                ).first()
+                if not m or m.role == OrgRole.OBSERVER:
+                    raise serializers.ValidationError({
+                        'assignee_id': 'Пользователь не может быть исполнителем в этой организации.'
+                    })
 
         return data
 

--- a/api/src/modules/crm/views.py
+++ b/api/src/modules/crm/views.py
@@ -15,7 +15,7 @@ from django.db.models import Subquery
 from .models import (
     Project, ProjectMember, Task, TaskComment, TaskAttachment, TimeLog,
     ProjectStatus, ProjectPriority, TaskStatus, TaskPriority,
-    Organization, OrganizationMember, OrganizationInvite
+    Organization, OrganizationMember, OrganizationInvite, OrgRole
 )
 from .serializers import (
     ProjectSerializer, ProjectListSerializer, ProjectMemberSerializer,
@@ -36,9 +36,15 @@ def lock_base_queryset(qs, model):
     # а лочим уже базовую таблицу по IN (SELECT ...).
     return model.objects.filter(pk__in=Subquery(qs.values('pk')))
 
+from .permissions import IsOrgObserverOrAbove, IsOrgMemberOrAbove, IsOrgAdminOrOwner
+
 User = get_user_model()
 
 MAX_BULK = 1000
+
+
+def _org_ids_user_is_in(user):
+    return OrganizationMember.objects.filter(user=user, status='accepted').values_list('organization_id', flat=True)
 
 
 class OrganizationViewSet(viewsets.ModelViewSet):
@@ -50,6 +56,18 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     search_fields = ['name']
     ordering_fields = ['name', 'created_at']
     ordering = ['name']
+
+    def get_permissions(self):
+        if self.action in ('list', 'retrieve', 'assignable_members'):
+            perms = [IsAuthenticated(), IsOrgObserverOrAbove()]
+        elif self.action in (
+            'update', 'partial_update', 'destroy', 'invite', 'members',
+            'manage_member', 'transfer_ownership'
+        ):
+            perms = [IsAuthenticated(), IsOrgAdminOrOwner()]
+        else:
+            perms = [IsAuthenticated()]
+        return perms
 
     def get_queryset(self):
         user = self.request.user
@@ -75,15 +93,11 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         )
 
     def update(self, request, *args, **kwargs):
-        org = self.get_object()
-        if not self._is_owner_or_admin(org, request.user):
-            return Response({'detail': 'Недостаточно прав'}, status=status.HTTP_403_FORBIDDEN)
+        self.get_object()
         return super().update(request, *args, **kwargs)
 
     def partial_update(self, request, *args, **kwargs):
-        org = self.get_object()
-        if not self._is_owner_or_admin(org, request.user):
-            return Response({'detail': 'Недостаточно прав'}, status=status.HTTP_403_FORBIDDEN)
+        self.get_object()
         return super().partial_update(request, *args, **kwargs)
 
     def destroy(self, request, *args, **kwargs):
@@ -97,8 +111,6 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     def invite(self, request, pk=None):
         """Пригласить пользователя в организацию (только админ/владелец)"""
         organization = self.get_object()
-        if not self._is_owner_or_admin(organization, request.user):
-            return Response({'detail': 'Недостаточно прав'}, status=status.HTTP_403_FORBIDDEN)
 
         email = request.data.get('email')
         role = request.data.get('role', organization.default_role)
@@ -116,32 +128,30 @@ class OrganizationViewSet(viewsets.ModelViewSet):
             invited_by=request.user,
         )
         return Response({'token': invite.token, 'status': invite.status}, status=status.HTTP_201_CREATED)
-    def _is_owner_or_admin(self, org, user):
-        return (
-            org.owner_id == user.id or
-            OrganizationMember.objects.filter(
-                organization=org,
-                user=user,
-                role__in=['owner', 'admin'],
-                status='accepted'
-            ).exists()
-        )
-
     @action(detail=True, methods=['get'])
     def members(self, request, pk=None):
         """Список участников организации"""
         organization = self.get_object()
-        if not self._is_owner_or_admin(organization, request.user):
-            return Response(status=status.HTTP_403_FORBIDDEN)
         serializer = OrganizationMemberSerializer(organization.memberships.all(), many=True)
         return Response(serializer.data)
+
+    @action(detail=True, methods=['get'])
+    def assignable_members(self, request, pk=None):
+        org = self.get_object()
+        members = org.memberships.select_related('user').exclude(role=OrgRole.OBSERVER)
+        data = [
+            {
+                'id': m.user_id,
+                'full_name': m.user.get_full_name() or m.user.username,
+            }
+            for m in members
+        ]
+        return Response(data)
 
     @action(detail=True, methods=['patch', 'delete'], url_path='members/(?P<user_id>[^/.]+)')
     def manage_member(self, request, pk=None, user_id=None):
         """Изменение роли или удаление участника"""
         organization = self.get_object()
-        if not self._is_owner_or_admin(organization, request.user):
-            return Response(status=status.HTTP_403_FORBIDDEN)
         try:
             member = OrganizationMember.objects.get(organization=organization, user_id=user_id)
         except OrganizationMember.DoesNotExist:
@@ -157,6 +167,8 @@ class OrganizationViewSet(viewsets.ModelViewSet):
             if role is not None:
                 if role not in dict(OrganizationMember.ROLE_CHOICES):
                     return Response({'error': 'invalid role'}, status=status.HTTP_400_BAD_REQUEST)
+                if member.is_owner():
+                    return Response({'error': 'cannot change owner role'}, status=status.HTTP_400_BAD_REQUEST)
                 if role == 'owner':
                     if organization.owner_id != request.user.id:
                         return Response({'error': 'invalid role'}, status=status.HTTP_400_BAD_REQUEST)
@@ -166,8 +178,8 @@ class OrganizationViewSet(viewsets.ModelViewSet):
                         OrganizationMember.objects.filter(
                             organization=organization,
                             user=request.user
-                        ).update(role='admin')
-                        member.role = 'owner'
+                        ).update(role=OrgRole.ADMIN)
+                        member.role = OrgRole.OWNER
                         member.save(update_fields=['role'])
                     return Response(OrganizationMemberSerializer(member).data)
                 member.role = role
@@ -413,6 +425,15 @@ class ProjectViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
     ordering_fields = ['created_at', 'start_date', 'end_date', 'priority']
     ordering = ['-created_at']
 
+    def get_permissions(self):
+        if self.action in ('list', 'retrieve'):
+            perms = [IsAuthenticated(), IsOrgObserverOrAbove()]
+        elif self.action in ('create', 'update', 'partial_update', 'destroy', 'bulk_delete', 'bulk_update'):
+            perms = [IsAuthenticated(), IsOrgMemberOrAbove()]
+        else:
+            perms = [IsAuthenticated()]
+        return perms
+
     def get_serializer_class(self):
         if self.action == 'list':
             return ProjectListSerializer
@@ -426,26 +447,20 @@ class ProjectViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
         if not user:
             return Project.objects.none()
 
-        queryset = super().get_queryset()
-
-        # Показываем проекты организаций, где пользователь владелец или участник,
-        # а также проекты без организации
-        queryset = queryset.filter(
-            Q(organization__owner=user) |
-            Q(organization__memberships__user=user, organization__memberships__status='accepted') |
-            Q(organization__isnull=True)
-        )
-
-        # Дополнительный фильтр "Мои проекты" (оставляем для совместимости)
-        my_projects = self.request.query_params.get('my_projects', None)
-        if not (my_projects and my_projects.lower() == 'false'):
-            queryset = queryset.filter(
-                Q(owner=user) |
-                Q(manager=user) |
-                Q(team_members=user)
-            )
-
-        return queryset.distinct()
+        qs = super().get_queryset()
+        org_ids = _org_ids_user_is_in(user)
+        org_id = self.request.query_params.get('organization')
+        if org_id:
+            try:
+                org_id_int = int(org_id)
+            except (TypeError, ValueError):
+                return qs.none()
+            if org_id_int not in org_ids:
+                return qs.none()
+            qs = qs.filter(organization_id=org_id_int)
+        else:
+            qs = qs.filter(organization_id__in=org_ids)
+        return qs
 
     @action(detail=True, methods=['post'])
     def add_member(self, request, pk=None):
@@ -577,6 +592,19 @@ class TaskViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
     ordering_fields = ['created_at', 'due_date', 'priority', 'kanban_order']
     ordering = ['kanban_order', '-created_at']
 
+    def get_permissions(self):
+        if self.action in ('list', 'retrieve'):
+            perms = [IsAuthenticated(), IsOrgObserverOrAbove()]
+        elif self.action in (
+            'create', 'update', 'partial_update', 'destroy',
+            'bulk_delete', 'bulk_update', 'add_comment', 'add_time_log',
+            'update_kanban_order', 'change_status'
+        ):
+            perms = [IsAuthenticated(), IsOrgMemberOrAbove()]
+        else:
+            perms = [IsAuthenticated()]
+        return perms
+
     def get_serializer_class(self):
         if self.action == 'list':
             return TaskListSerializer
@@ -594,42 +622,29 @@ class TaskViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
         if not user:
             return Task.objects.none()
 
-        queryset = super().get_queryset()
-
-        # Ограничиваем задачи организациями, где пользователь владелец
-        # или принятый участник, а также задачи без организации
-        queryset = queryset.filter(
-            Q(organization__owner=user) |
-            Q(organization__memberships__user=user, organization__memberships__status='accepted') |
-            Q(organization__isnull=True)
-        )
-
-        # Параметр "Мои задачи"
-        my_tasks = self.request.query_params.get('my_tasks', None)
-
-        if my_tasks and my_tasks.lower() == 'true':
-            # Только мои задачи - только задачи, где я исполнитель
-            queryset = queryset.filter(assignee=user).distinct()
+        qs = super().get_queryset()
+        org_ids = _org_ids_user_is_in(user)
+        org_id = self.request.query_params.get('organization')
+        if org_id:
+            try:
+                org_id_int = int(org_id)
+            except (TypeError, ValueError):
+                return qs.none()
+            if org_id_int not in org_ids:
+                return qs.none()
+            qs = qs.filter(organization_id=org_id_int)
         else:
-            # Показываем все задачи из проектов, в которых пользователь участвует
-            queryset = queryset.filter(
-                Q(project__owner=user) |
-                Q(project__manager=user) |
-                Q(project__team_members=user) |
-                Q(assignee=user) |
-                Q(creator=user)
-            ).distinct()
+            qs = qs.filter(organization_id__in=org_ids)
 
-        # Фильтр по дате для календаря
-        start_date = self.request.query_params.get('start_date', None)
-        end_date = self.request.query_params.get('end_date', None)
+        start_date = self.request.query_params.get('start_date')
+        end_date = self.request.query_params.get('end_date')
         if start_date and end_date:
-            queryset = queryset.filter(
+            qs = qs.filter(
                 Q(start_date__range=[start_date, end_date]) |
                 Q(due_date__range=[start_date, end_date])
             )
 
-        return queryset
+        return qs
 
     @action(detail=False, methods=['delete'], url_path='bulk-delete')
     def bulk_delete(self, request, *args, **kwargs):

--- a/client/src/modules/crm/organizations/OrganizationDetails.vue
+++ b/client/src/modules/crm/organizations/OrganizationDetails.vue
@@ -162,7 +162,7 @@
               <span>Роль приглашённых по умолчанию</span>
               <select v-model="editForm.default_role" class="input">
                 <option value="member">member</option>
-                <option value="viewer">viewer</option>
+                <option value="observer">observer</option>
                 <option value="admin">admin</option>
               </select>
             </label>
@@ -493,25 +493,19 @@ export default {
       return 'text-muted';
     };
 
-    const taskLink = (task) => ({
-      path: '/crm/project-management',
-      query: { tab: 'tasks', open: task.id }
-    });
+    const taskLink = (task) => `/crm/project-management/task/${task.id}`;
 
     // ====== ПРАВА (как в списке) ======
     const toStr = v => (v == null ? null : String(v));
     const uid = computed(() => toStr(user.value?.id ?? profile.value?.id));
-    const ownerIdFromOrg = computed(() => toStr(org.value?.owner?.id ?? org.value?.owner_id));
 
-    const isOwner = computed(() =>
-      org.value?.my_role === 'owner' || (uid.value && ownerIdFromOrg.value === uid.value)
-    );
+    const isObserver = computed(() => org.value?.my_role === 'observer');
+    const isOwner = computed(() => org.value?.my_role === 'owner');
+    const isAdmin = computed(() => ['admin', 'owner'].includes(org.value?.my_role));
+    const isMember = computed(() => ['member', 'admin', 'owner'].includes(org.value?.my_role));
 
-    const isAdminFromMembers = computed(() => ['admin', 'owner'].includes(myMember.value?.role));
-    const isAdmin = computed(() => org.value?.my_role === 'admin' || isAdminFromMembers.value);
-
-    const canInvite = computed(() => isOwner.value || isAdmin.value);
-    const canManage = canInvite;
+    const canInvite = computed(() => isAdmin.value);
+    const canManage = computed(() => isAdmin.value);
 
     function updateMyMember() {
       myMember.value = members.value.find(m => toStr(m.user?.id) === uid.value) || null;
@@ -524,7 +518,7 @@ export default {
       (toStr(o?.owner?.id ?? o?.owner_id) === uid.value ? 'owner' : 'member');
 
     const memberRoles = computed(() =>
-      isOwner.value ? ['owner', 'admin', 'member', 'viewer'] : ['admin', 'member', 'viewer']
+      isOwner.value ? ['owner', 'admin', 'member', 'observer'] : ['admin', 'member', 'observer']
     );
 
     const canChangeRole = (m) =>
@@ -650,7 +644,7 @@ export default {
 
       // права
       uid, toStr,
-      isParticipant, isOwner, isAdmin, canInvite, canManage, myRole,
+      isParticipant, isObserver, isMember, isOwner, isAdmin, canInvite, canManage, myRole,
       membersCount,
 
       // members

--- a/client/src/modules/crm/organizations/OrganizationForm.vue
+++ b/client/src/modules/crm/organizations/OrganizationForm.vue
@@ -68,7 +68,7 @@
         <label>Роль по умолчанию</label>
         <select v-model="form.default_role" class="select">
           <option value="member">member</option>
-          <option value="viewer">viewer</option>
+          <option value="observer">observer</option>
         </select>
       </div>
 

--- a/client/src/modules/crm/organizations/components/OrganizationInviteModal.vue
+++ b/client/src/modules/crm/organizations/components/OrganizationInviteModal.vue
@@ -22,7 +22,7 @@
             <select v-model="role" class="input">
               <option value="member">member</option>
               <option value="admin">admin</option>
-              <option value="viewer">viewer</option>
+              <option value="observer">observer</option>
             </select>
             <small class="muted">По умолчанию: {{ org?.default_role || 'member' }}</small>
           </label>
@@ -50,7 +50,7 @@ export default {
   data() {
     return {
       email: '',
-      role: this.org?.default_role && ['member', 'admin', 'viewer'].includes(this.org.default_role)
+      role: this.org?.default_role && ['member', 'admin', 'observer'].includes(this.org.default_role)
         ? this.org.default_role
         : 'member',
     };

--- a/client/src/modules/crm/organizations/js/organizationApi.js
+++ b/client/src/modules/crm/organizations/js/organizationApi.js
@@ -56,6 +56,9 @@ class OrganizationApi {
   }
   async getProjects(orgId) { return await this.client.get(`/crm/projects/`, { params: { organization: orgId } }); }
   async getTasks(orgId) { return await this.client.get(`/crm/tasks/`, { params: { organization: orgId } }); }
+  getAssignableMembers(orgId) {
+    return this.client.get(`/crm/organizations/${orgId}/assignable_members/`);
+  }
 
   // invites
   async inviteToOrganization(orgId, data) { return await this.client.post(`/crm/organizations/${orgId}/invite/`, data); }


### PR DESCRIPTION
## Summary
- add explicit organization roles with helper methods
- enforce org-based permissions and expose assignable members endpoint
- adjust client UI to new roles and open tasks directly

## Testing
- `PYTHONPATH=api python api/src/manage.py test crm --noinput` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'src/core')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b88dc300083298b5cd04c2313cd75