### PR TITLE
Expand CRM project/task visibility and assignable users

### DIFF
--- a/api/src/modules/crm/views.py
+++ b/api/src/modules/crm/views.py
@@ -448,19 +448,34 @@ class ProjectViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
             return Project.objects.none()
 
         qs = super().get_queryset()
-        org_ids = _org_ids_user_is_in(user)
+        org_ids = list(_org_ids_user_is_in(user))
+
+        visible_q = (
+            Q(organization_id__in=org_ids) |
+            Q(owner_id=user.id) |
+            Q(manager_id=user.id) |
+            Q(memberships__user_id=user.id)
+        )
+
         org_id = self.request.query_params.get('organization')
         if org_id:
             try:
                 org_id_int = int(org_id)
             except (TypeError, ValueError):
-                return qs.none()
+                return Project.objects.none()
             if org_id_int not in org_ids:
-                return qs.none()
+                return Project.objects.none()
             qs = qs.filter(organization_id=org_id_int)
         else:
-            qs = qs.filter(organization_id__in=org_ids)
-        return qs
+            qs = qs.filter(visible_q)
+
+        my_projects = str(self.request.query_params.get('my_projects', '')).lower() in {'1', 'true', 'yes'}
+        if my_projects:
+            qs = qs.filter(
+                Q(owner_id=user.id) | Q(manager_id=user.id) | Q(memberships__user_id=user.id)
+            )
+
+        return qs.distinct()
 
     @action(detail=True, methods=['post'])
     def add_member(self, request, pk=None):
@@ -537,6 +552,28 @@ class ProjectViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
             'overdue_tasks': overdue_tasks,
             'progress': round((completed_tasks / total_tasks * 100) if total_tasks > 0 else 0)
         })
+
+    @action(detail=True, methods=['get'])
+    def assignable_users(self, request, pk=None):
+        """Пользователи, которых можно назначить исполнителями:
+        - org: все кроме observer + создатель проекта;
+        - без org: только создатель проекта."""
+        project = self.get_object()
+        users = []
+        if project.organization_id:
+            members = project.organization.memberships.select_related('user').exclude(role=OrgRole.OBSERVER)
+            users = [
+                {'id': m.user_id, 'full_name': m.user.get_full_name() or m.user.username}
+                for m in members
+            ]
+            owner = project.owner
+            if owner and not any(u['id'] == owner.id for u in users):
+                users.insert(0, {'id': owner.id, 'full_name': owner.get_full_name() or owner.username})
+        else:
+            owner = project.owner
+            if owner:
+                users = [{'id': owner.id, 'full_name': owner.get_full_name() or owner.username}]
+        return Response(users)
 
     @action(detail=False, methods=['delete'], url_path='bulk-delete')
     def bulk_delete(self, request, *args, **kwargs):
@@ -623,18 +660,32 @@ class TaskViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
             return Task.objects.none()
 
         qs = super().get_queryset()
-        org_ids = _org_ids_user_is_in(user)
+        org_ids = list(_org_ids_user_is_in(user))
+
+        visible_q = (
+            Q(organization_id__in=org_ids) |
+            Q(project__memberships__user_id=user.id) |
+            Q(project__owner_id=user.id) |
+            Q(project__manager_id=user.id) |
+            Q(assignee_id=user.id) |
+            Q(creator_id=user.id)
+        )
+
         org_id = self.request.query_params.get('organization')
         if org_id:
             try:
                 org_id_int = int(org_id)
             except (TypeError, ValueError):
-                return qs.none()
+                return Task.objects.none()
             if org_id_int not in org_ids:
-                return qs.none()
+                return Task.objects.none()
             qs = qs.filter(organization_id=org_id_int)
         else:
-            qs = qs.filter(organization_id__in=org_ids)
+            qs = qs.filter(visible_q)
+
+        my_tasks = str(self.request.query_params.get('my_tasks', '')).lower() in {'1', 'true', 'yes'}
+        if my_tasks:
+            qs = qs.filter(Q(assignee_id=user.id) | Q(creator_id=user.id))
 
         start_date = self.request.query_params.get('start_date')
         end_date = self.request.query_params.get('end_date')
@@ -644,7 +695,7 @@ class TaskViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
                 Q(due_date__range=[start_date, end_date])
             )
 
-        return qs
+        return qs.distinct()
 
     @action(detail=False, methods=['delete'], url_path='bulk-delete')
     def bulk_delete(self, request, *args, **kwargs):

--- a/client/src/modules/crm/project-management/KanbanBoard.vue
+++ b/client/src/modules/crm/project-management/KanbanBoard.vue
@@ -369,7 +369,6 @@
 <script>
 import { Modal } from 'bootstrap'
 import projectManagementApi from '@/modules/crm/project-management/js/projectManagementApi.js'
-import OrganizationApi from '@/modules/crm/organizations/js/organizationApi.js'
 import { useNotifications } from '@/modules/lms/composables/useNotifications'
 import { getAvatarUrl } from '@/modules/cms/js/avatarUtils.js'
 
@@ -518,14 +517,10 @@ export default {
     async loadUsersForProject(projectId) {
       try {
         if (projectId) {
-          const proj = this.projects.find(p => p.id === projectId)
-          const orgId = proj?.organization?.id
-          if (orgId) {
-            const resp = await OrganizationApi.getOrganizationMembers(orgId)
-            const members = Array.isArray(resp.data.results) ? resp.data.results : (resp.data || [])
-            this.users = members.map(m => m.user || m).filter(u => u && u.id)
-            return
-          }
+          const resp = await projectManagementApi.getProjectAssignableUsers(projectId)
+          const members = Array.isArray(resp.data) ? resp.data : []
+          this.users = members.map(u => ({ id: u.id, full_name: u.full_name })).filter(u => u && u.id)
+          return
         }
         await this.loadAllUsers()
       } catch (error) {

--- a/client/src/modules/crm/project-management/ProjectDetail.vue
+++ b/client/src/modules/crm/project-management/ProjectDetail.vue
@@ -884,10 +884,10 @@ export default {
     async loadUsers() {
       this.loadingUsers = true
       try {
-        if (this.project?.organization?.id) {
-          const resp = await OrganizationApi.getOrganizationMembers(this.project.organization.id)
-          const members = Array.isArray(resp.data.results) ? resp.data.results : (resp.data || [])
-          this.users = members.map(m => m.user || m).filter(u => u && u.id)
+        if (this.project?.id) {
+          const resp = await projectManagementApi.getProjectAssignableUsers(this.project.id)
+          const members = Array.isArray(resp.data) ? resp.data : []
+          this.users = members.map(u => ({ id: u.id, full_name: u.full_name })).filter(u => u && u.id)
         } else {
           const response = await projectManagementApi.getUsers()
           const users = Array.isArray(response.data.results) ? response.data.results :

--- a/client/src/modules/crm/project-management/TaskCalendar.vue
+++ b/client/src/modules/crm/project-management/TaskCalendar.vue
@@ -457,7 +457,6 @@
 import { ChevronLeft, ChevronRight, Calendar, ChevronsLeft, ChevronsRight } from 'lucide-vue-next'
 import { Modal } from 'bootstrap'
 import projectManagementApi from '@/modules/crm/project-management/js/projectManagementApi.js'
-import OrganizationApi from '@/modules/crm/organizations/js/organizationApi.js'
 import { useNotifications } from '@/modules/lms/composables/useNotifications'
 
 export default {
@@ -657,14 +656,10 @@ export default {
     async loadUsersForProject(projectId) {
       try {
         if (projectId) {
-          const proj = this.projects.find(p => p.id === projectId)
-          const orgId = proj?.organization?.id
-          if (orgId) {
-            const resp = await OrganizationApi.getOrganizationMembers(orgId)
-            const members = Array.isArray(resp.data.results) ? resp.data.results : (resp.data || [])
-            this.users = members.map(m => m.user || m).filter(u => u && u.id)
-            return
-          }
+          const resp = await projectManagementApi.getProjectAssignableUsers(projectId)
+          const members = Array.isArray(resp.data) ? resp.data : []
+          this.users = members.map(u => ({ id: u.id, full_name: u.full_name })).filter(u => u && u.id)
+          return
         }
         await this.loadAllUsers()
       } catch (error) {

--- a/client/src/modules/crm/project-management/TasksList.vue
+++ b/client/src/modules/crm/project-management/TasksList.vue
@@ -525,7 +525,6 @@
 import { Modal } from 'bootstrap'
 import { Edit, Trash2, Plus } from 'lucide-vue-next'
 import projectManagementApi from '@/modules/crm/project-management/js/projectManagementApi.js'
-import OrganizationApi from '@/modules/crm/organizations/js/organizationApi.js'
 import { useNotifications } from '@/modules/lms/composables/useNotifications'
 import { getAvatarUrl } from '@/modules/cms/js/avatarUtils.js'
 import BulkActionsBar from './components/BulkActionsBar.vue'
@@ -737,14 +736,10 @@ export default {
       this.loadingUsers = true
       try {
         if (projectId) {
-          const proj = this.projects.find(p => p.id === projectId)
-          const orgId = proj?.organization?.id
-          if (orgId) {
-            const resp = await OrganizationApi.getOrganizationMembers(orgId)
-            const members = Array.isArray(resp.data.results) ? resp.data.results : (resp.data || [])
-            this.users = members.map(m => m.user || m).filter(u => u && u.id)
-            return
-          }
+          const resp = await projectManagementApi.getProjectAssignableUsers(projectId)
+          const members = Array.isArray(resp.data) ? resp.data : []
+          this.users = members.map(u => ({ id: u.id, full_name: u.full_name })).filter(u => u && u.id)
+          return
         }
         await this.loadAllUsers()
       } catch (error) {

--- a/client/src/modules/crm/project-management/js/projectManagementApi.js
+++ b/client/src/modules/crm/project-management/js/projectManagementApi.js
@@ -69,6 +69,9 @@ class ProjectManagementApi {
     async getProjectStatistics(projectId) {
         return await this.client.get(`/crm/projects/${projectId}/statistics/`);
     }
+    async getProjectAssignableUsers(projectId) {
+        return await this.client.get(`/crm/projects/${projectId}/assignable_users/`);
+    }
 
     async addProjectMember(projectId, userData) {
         return await this.client.post(`/crm/projects/${projectId}/add_member/`, userData);


### PR DESCRIPTION
## Summary
- broaden project and task visibility for non-member owners and assignees
- add endpoint exposing assignable users per project
- use new endpoint and filters in project management UI

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b9bff0ed883298bd82d3e6bd66912