### PR TITLE
Fix LMS stats and badges endpoints

### DIFF
--- a/api/src/modules/lms/services/statistics.py
+++ b/api/src/modules/lms/services/statistics.py
@@ -1,14 +1,93 @@
+"""Utility functions for LMS statistics."""
+
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
+
+from django.db.models import Count, F
+
+from ..models import Enrollment, Lesson
+
+
+def _lessons_count_for_subjects(subject_ids: Iterable[int]) -> Dict[int, int]:
+    """Return mapping of subject_id -> total lessons for given subjects."""
+
+    counts = (
+        Lesson.objects.filter(theme__subject_id__in=subject_ids)
+        .values("theme__subject_id")
+        .annotate(total=Count("id", distinct=True))
+    )
+    return {row["theme__subject_id"]: row["total"] for row in counts}
+
+
+def calculate_user_stats(user) -> Dict[str, Any]:
+    """Calculate statistics for a particular user.
+
+    The function aggregates information about all enrollments of the user
+    and returns data required by the ``/api/lms/stats`` endpoint.
+    """
+
+    enrollments = (
+        Enrollment.objects.filter(student=user, status__in=["active", "completed"])
+        .select_related("subject")
+    )
+
+    subject_ids = list(enrollments.values_list("subject_id", flat=True))
+    lessons_map = _lessons_count_for_subjects(subject_ids)
+
+    courses = []
+    total_courses_enrolled = enrollments.count()
+    total_courses_completed = 0
+    weighted_sum = 0
+    weight_total = 0
+
+    for en in enrollments:
+        total = lessons_map.get(en.subject_id, 0)
+        completed = int(round((en.progress_percentage or 0) * total / 100))
+        percent = int(round(en.progress_percentage or 0))
+
+        if percent >= 100 or en.status == "completed":
+            total_courses_completed += 1
+
+        weight = total or 1
+        weighted_sum += percent * weight
+        weight_total += weight
+
+        courses.append(
+            {
+                "course_id": en.subject_id,
+                "title": en.subject.name,
+                "lessons_total": total,
+                "lessons_required": total,
+                "lessons_completed": completed,
+                "percent": percent,
+                "started_at": en.enrollment_date,
+                "completed_at": en.completion_date,
+            }
+        )
+
+    overall_percent = int(round(weighted_sum / weight_total)) if weight_total else 0
+
+    return {
+        "total_courses_enrolled": total_courses_enrolled,
+        "total_courses_completed": total_courses_completed,
+        "overall_percent": overall_percent,
+        "courses": courses,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Legacy placeholder
+# ---------------------------------------------------------------------------
 
 
 def get_user_overview(user, category_id=None) -> Dict[str, Any]:
     """Return aggregated LMS stats for the given user.
 
-    The implementation currently provides placeholder values and
-    determines the user role based on simple flags. Real aggregation
-    logic can be implemented later on top of project models.
+    This helper is used by some existing views.  The implementation keeps a
+    backward compatible placeholder and does **not** attempt to provide full
+    statistics.  New code should rely on :func:`calculate_user_stats` instead.
     """
+
     role = "student"
     if getattr(user, "is_staff", False):
         role = "admin"

--- a/api/src/modules/lms/tests/test_stats_badges.py
+++ b/api/src/modules/lms/tests/test_stats_badges.py
@@ -1,0 +1,92 @@
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase
+from django.urls import reverse
+
+from ..models import (
+    UserRole,
+    Subject,
+    Theme,
+    Lesson,
+    Enrollment,
+    Badge,
+    UserBadge,
+)
+
+
+class StatsBadgesAPITest(APITestCase):
+    def setUp(self):
+        # create users
+        self.student = User.objects.create_user(username="student", password="pass")
+        self.teacher = User.objects.create_user(username="teacher", password="pass")
+
+        UserRole.objects.create(user=self.student, role="student")
+        UserRole.objects.create(user=self.teacher, role="teacher")
+
+        # create courses
+        self.subject1 = Subject.objects.create(name="Course 1", teacher=self.teacher)
+        self.subject2 = Subject.objects.create(name="Course 2", teacher=self.teacher)
+
+        # themes and lessons
+        theme1 = Theme.objects.create(name="T1", subject=self.subject1)
+        theme2 = Theme.objects.create(name="T2", subject=self.subject2)
+        for i in range(3):
+            Lesson.objects.create(name=f"L1-{i}", theme=theme1)
+        for i in range(4):
+            Lesson.objects.create(name=f"L2-{i}", theme=theme2)
+
+        # enrollments
+        Enrollment.objects.create(
+            student=self.student,
+            subject=self.subject1,
+            status="completed",
+            progress_percentage=100,
+        )
+        Enrollment.objects.create(
+            student=self.student,
+            subject=self.subject2,
+            status="active",
+            progress_percentage=50,
+        )
+
+        # badges
+        self.badge1 = Badge.objects.create(
+            name="Badge 1", badge_type="course_completion", subject=self.subject1
+        )
+        self.badge2 = Badge.objects.create(
+            name="Badge 2", badge_type="course_completion", subject=self.subject2
+        )
+        UserBadge.objects.create(user=self.student, badge=self.badge1)
+
+    def test_student_stats(self):
+        self.client.force_authenticate(self.student)
+        url = "/api/lms/stats/"
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["total_courses_enrolled"], 2)
+        self.assertEqual(data["total_courses_completed"], 1)
+        self.assertIn("courses", data)
+        self.assertEqual(len(data["courses"]), 2)
+
+    def test_badges(self):
+        self.client.force_authenticate(self.student)
+        resp = self.client.get("/api/lms/badges/")
+        self.assertEqual(resp.status_code, 200)
+        cats = resp.json()
+        self.assertEqual(len(cats), 1)
+        cat = cats[0]
+        self.assertEqual(cat["earned_count"], 1)
+        self.assertEqual(len(cat["badges"]), 2)
+
+    def test_teacher_can_view_student(self):
+        self.client.force_authenticate(self.teacher)
+        resp = self.client.get("/api/lms/stats/", {"user_id": self.student.id})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_student_cannot_view_other(self):
+        other = User.objects.create_user(username="other", password="pass")
+        UserRole.objects.create(user=other, role="student")
+        self.client.force_authenticate(self.student)
+        resp = self.client.get("/api/lms/stats/", {"user_id": other.id})
+        self.assertEqual(resp.status_code, 403)
+

--- a/api/src/modules/lms/tests/urls.py
+++ b/api/src/modules/lms/tests/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from src.modules.lms.views import LmsStatsViewSet, UserBadgesView
+
+router = DefaultRouter()
+router.register(r'stats', LmsStatsViewSet, basename='lms-stats')
+
+urlpatterns = [
+    path('api/lms/badges/', UserBadgesView.as_view()),
+    path('api/lms/', include(router.urls)),
+]

--- a/api/src/modules/lms/urls.py
+++ b/api/src/modules/lms/urls.py
@@ -6,13 +6,14 @@ from src.modules.lms.views import (
     ThemeViewSet, LessonViewSet, ResourceViewSet, ForumViewSet, ForumDiscussionViewSet,
     ForumPostViewSet, TestBankViewSet, TestViewSet, TestAttemptViewSet,
     AssignmentViewSet, SubmittedAssignmentViewSet,
-    CalendarEventViewSet, BadgeViewSet, UserBadgeViewSet,
+    CalendarEventViewSet, UserBadgeViewSet,
     NotificationViewSet, PrivateMessageViewSet, UserRoleViewSet,
     QuestionViewSet, AnswerViewSet, LessonItemViewSet,
     LmsStatsViewSet,
     StudentStatsView,
     TeacherStatsView,
     BadgesSummaryView,
+    UserBadgesView,
 )
 
 # Создаем роутер для API
@@ -40,7 +41,6 @@ router.register(r'test-attempts', TestAttemptViewSet, basename='testattempt')
 router.register(r'assignments', AssignmentViewSet, basename='assignment')
 router.register(r'submitted-assignments', SubmittedAssignmentViewSet, basename='submittedassignment')
 router.register(r'calendar', CalendarEventViewSet, basename='calendarevent')
-router.register(r'badges', BadgeViewSet, basename='badge')
 router.register(r'user-badges', UserBadgeViewSet, basename='userbadge')
 router.register(r'notifications', NotificationViewSet, basename='notification')
 router.register(r'messages', PrivateMessageViewSet, basename='privatemessage')
@@ -62,6 +62,7 @@ urlpatterns = [
 
     path('stats/student/', StudentStatsView.as_view(), name='lms-stats-student'),
     path('stats/teacher/', TeacherStatsView.as_view(), name='lms-stats-teacher'),
+    path('badges/', UserBadgesView.as_view(), name='lms-badges'),
     path('badges/summary/', BadgesSummaryView.as_view(), name='lms-badges-summary'),
     
     # Endpoints для профиля

--- a/api/src/modules/lms/views.py
+++ b/api/src/modules/lms/views.py
@@ -47,7 +47,7 @@ from .serializers import (
     UserLmsOverviewSerializer
 )
 
-from .services.statistics import get_user_overview
+from .services.statistics import get_user_overview, calculate_user_stats
 from rest_framework.views import APIView
 
 
@@ -1944,13 +1944,90 @@ class LessonItemViewSet(SwaggerSafeMixin, viewsets.ModelViewSet):
 
 class LmsStatsViewSet(viewsets.ViewSet):
     permission_classes = [permissions.IsAuthenticated]
+    """Endpoint returning course progress statistics for a user."""
+
+    def _get_target_user(self, request):
+        """Return user whose stats should be returned respecting permissions."""
+
+        user = request.user
+        requested_id = request.query_params.get("user_id")
+        if requested_id and user.roles.filter(role__in=["teacher", "admin"], is_active=True).exists():
+            return User.objects.get(pk=requested_id)
+        if requested_id and not user.roles.filter(role__in=["teacher", "admin"], is_active=True).exists():
+            raise PermissionDenied("Not allowed to view other users' statistics")
+        return user
+
+    def list(self, request):
+        target = self._get_target_user(request)
+        data = calculate_user_stats(target)
+        return Response(data)
 
     @action(detail=False, methods=["get"], url_path="overview")
     def overview(self, request):
+        """Legacy dashboard overview used by existing front-end."""
         category = request.query_params.get("category")
         data = get_user_overview(request.user, category_id=category)
         serializer = UserLmsOverviewSerializer(data)
         return Response(serializer.data)
+
+
+class UserBadgesView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def _get_target_user(self, request):
+        user = request.user
+        requested_id = request.query_params.get("user_id")
+        if requested_id and user.roles.filter(role__in=["teacher", "admin"], is_active=True).exists():
+            return User.objects.get(pk=requested_id)
+        if requested_id and not user.roles.filter(role__in=["teacher", "admin"], is_active=True).exists():
+            raise PermissionDenied("Not allowed to view other users' badges")
+        return user
+
+    def get(self, request):
+        target = self._get_target_user(request)
+
+        badges = Badge.objects.filter(is_active=True).order_by("badge_type", "id")
+        awarded = {
+            ub.badge_id: ub
+            for ub in UserBadge.objects.filter(user=target, badge__in=badges).select_related("badge")
+        }
+
+        categories = {}
+        for badge in badges:
+            cat = badge.badge_type
+            cat_obj = categories.setdefault(
+                cat,
+                {
+                    "id": cat,
+                    "name": cat.replace("_", " ").title(),
+                    "earned_count": 0,
+                    "badges": [],
+                },
+            )
+
+            awarded_obj = awarded.get(badge.id)
+            earned = bool(awarded_obj)
+            if earned:
+                cat_obj["earned_count"] += 1
+
+            cat_obj["badges"].append(
+                {
+                    "id": badge.id,
+                    "title": badge.name,
+                    "earned": earned,
+                    "earned_at": awarded_obj.awarded_at if earned else None,
+                    "progress": None,
+                    "threshold": None,
+                }
+            )
+
+        result = []
+        for cat in categories.values():
+            next_badge = next((b for b in cat["badges"] if not b["earned"]), None)
+            cat["next_badge"] = next_badge
+            result.append(cat)
+
+        return Response(result)
 
 
 class StudentStatsView(APIView):

--- a/api/test_settings.py
+++ b/api/test_settings.py
@@ -1,0 +1,16 @@
+SECRET_KEY = 'test'
+INSTALLED_APPS = [
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'rest_framework',
+    'src.modules.lms',
+]
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+USE_TZ = True
+ROOT_URLCONF = 'src.modules.lms.tests.urls'
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/client/src/modules/lms/js/lmsApi.js
+++ b/client/src/modules/lms/js/lmsApi.js
@@ -141,10 +141,13 @@ export const lmsApi = {
   getTeacherStats(params) {
     return apiClient.get('/api/lms/stats/teacher', { params })
   },
-  getBadgesSummary(params) {
-    return apiClient.get('/api/lms/badges/summary', { params })
+  getStats(params) {
+    return apiClient.get('/api/lms/stats', { params })
   },
-
+  getBadges(params) {
+    return apiClient.get('/api/lms/badges', { params })
+  },
+  
   // Статистика студента
   async getStudentStats() {
     try {


### PR DESCRIPTION
## Summary
- implement real `/api/lms/stats` endpoint with course progress aggregation
- add `/api/lms/badges` user badges endpoint with role-based access
- expose new API client methods and create tests for stats and badges

## Testing
- `PYTHONPATH=/workspace/ergo_ms/api DJANGO_SETTINGS_MODULE=test_settings python -m django test src.modules.lms.tests.test_stats_badges -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689bc54e4fac83299528b9aba5966041